### PR TITLE
Direct badges to v3 tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OPTIMADE client (in Jupyter)
 
-[![Materials Cloud](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/aiidalab/aiidalab-optimade/pure_jupyter_version/docs/resources/mcloud_badge.json)](https://dev-tools.materialscloud.org/optimadeclient/)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/aiidalab/aiidalab-optimade/pure_jupyter_version?urlpath=%2Fapps%2FOPTIMADE_general.ipynb)
+[![Materials Cloud](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/aiidalab/aiidalab-optimade/v3/docs/resources/mcloud_badge.json)](https://dev-tools.materialscloud.org/optimadeclient/)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/aiidalab/aiidalab-optimade/v3?urlpath=%2Fapps%2FOPTIMADE_general.ipynb)
 
 Query for and import structures from [OPTIMADE](https://www.optimade.org) providers (COD, Materials Cloud, NoMaD, Materials Project, OQMD, and more ...)  
 Note, this application handles the structures by converting them to ASE `Atoms` or AiiDA `StructureData` objects.


### PR DESCRIPTION
After merging this, a `v3` tag must be created.

The idea is to have the `v3` tag _always_ point at the newest v3.X.Y version, i.e., the "pure" Jupyter version.