### PR TITLE
Utilize ASE and pymatgen for structure format conversion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/aiidalab_optimade/query_filter.py
+++ b/aiidalab_optimade/query_filter.py
@@ -19,7 +19,6 @@ from aiidalab_optimade.subwidgets import (
     ResultsPageChooser,
 )
 from aiidalab_optimade.utils import (
-    validate_api_version,
     perform_optimade_query,
     handle_errors,
     TIMEOUT_SECONDS,
@@ -300,15 +299,7 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
             msg = handle_errors(response)
             if msg:
                 self.error_or_status_messages.value = msg
-                raise QueryError(remove_target=False)
-
-            # Check implementation API version
-            msg = validate_api_version(
-                response.get("meta", {}).get("api_version", ""), raise_on_fail=False
-            )
-            if msg:
-                self.error_or_status_messages.value = msg
-                raise QueryError(remove_target=True)
+                raise QueryError(msg)
 
             # Update list of structures in dropdown widget
             self._update_structures(response["data"])

--- a/aiidalab_optimade/summary.py
+++ b/aiidalab_optimade/summary.py
@@ -1,14 +1,29 @@
+import base64
+import tempfile
+from typing import Union
+import warnings
+
 import ipywidgets as ipw
 import traitlets
 
 import nglview
 
+from ase import Atoms as aseAtoms
+
+try:
+    from pymatgen import Molecule as pymatgenMolecule, Structure as pymatgenStructure
+except ImportError:
+    pymatgenMolecule = None
+    pymatgenStructure = None
+
 from optimade.adapters import Structure
 
+from aiidalab_optimade import exceptions
 from aiidalab_optimade.subwidgets import (
     StructureSummary,
     StructureSites,
 )
+from aiidalab_optimade.warnings import OptimadeClientWarning
 
 
 class OptimadeSummaryWidget(ipw.VBox):
@@ -68,12 +83,39 @@ class DownloadChooser(ipw.HBox):
     structure = traitlets.Instance(Structure, allow_none=True)
 
     _formats = [
-        ("Select a format", {}),
         (
             "Crystallographic Information File v1.0 (.cif)",
-            {"ext": "cif", "adapter_format": "cif"},
+            {"ext": ".cif", "adapter_format": "cif"},
         ),
-        ("Protein Data Bank (.pdb)", {"ext": "pdb", "adapter_format": "pdb"}),
+        ("Protein Data Bank (.pdb)", {"ext": ".pdb", "adapter_format": "pdb"}),
+        (
+            "Crystallographic Information File v1.0 [via ASE] (.cif)",
+            {"ext": ".cif", "adapter_format": "ase", "final_format": "cif"},
+        ),
+        (
+            "Protein Data Bank [via ASE] (.pdb)",
+            {"ext": ".pdb", "adapter_format": "ase", "final_format": "proteindatabank"},
+        ),
+        (
+            "XMol XYZ File [via ASE] (.xyz)",
+            {"ext": ".xyz", "adapter_format": "ase", "final_format": "xyz"},
+        ),
+        (
+            "XCrySDen Structure File [via ASE] (.xsf)",
+            {"ext": ".xsf", "adapter_format": "ase", "final_format": "xsf"},
+        ),
+        (
+            "WIEN2k Structure File [via ASE] (.struct)",
+            {"ext": ".struct", "adapter_format": "ase", "final_format": "struct"},
+        ),
+        (
+            "VASP POSCAR File [via ASE]",
+            {"ext": "", "adapter_format": "ase", "final_format": "vasp"},
+        ),
+        (
+            "Quantum ESPRESSO File [via ASE] (.in)",
+            {"ext": ".in", "adapter_format": "ase", "final_format": "espresso-in"},
+        ),
         # Not yet implemented:
         # (
         #     "Protein Data Bank, macromolecular CIF v1.1 (PDBx/mmCIF) (.cif)",
@@ -91,7 +133,9 @@ document.body.removeChild(link);" />
 """
 
     def __init__(self, **kwargs):
-        self.dropdown = ipw.Dropdown(options=self._formats, width="auto")
+        options = sorted(self._formats)
+        options.insert(0, ("Select a format", {}))
+        self.dropdown = ipw.Dropdown(options=options, width="auto")
         self.download_button = ipw.HTML(
             self._download_button_format.format(
                 disabled="disabled", encoding="", data="", filename=""
@@ -112,9 +156,13 @@ document.body.removeChild(link);" />
         self.unfreeze()
 
     def _update_download_button(self, change: dict):
-        """Update Download button with correct onclick value"""
-        import base64
+        """Update Download button with correct onclick value
 
+        The whole parsing process from `Structure` to desired format, is wrapped in a try/except,
+        which is further wrapped in a `warnings.catch_warnings()`.
+        This is in order to be able to log any warnings that might be thrown by the adapter in
+        `optimade-python-tools` and/or any related exceptions.
+        """
         desired_format = change["new"]
         if not desired_format or desired_format is None:
             self.download_button.value = self._download_button_format.format(
@@ -122,20 +170,85 @@ document.body.removeChild(link);" />
             )
             return
 
-        output = getattr(self.structure, f"as_{desired_format['adapter_format']}")
-        encoding = "utf-8"
+        with warnings.catch_warnings():
+            warnings.filterwarnings("error")
 
-        # Specifically for CIF: v1.x CIF needs to be in "latin-1" formatting
-        if desired_format["ext"] == "cif":
-            encoding = "latin-1"
+            try:
+                output = getattr(
+                    self.structure, f"as_{desired_format['adapter_format']}"
+                )
 
-        filename = f"optimade_structure_{self.structure.id}.{desired_format['ext']}"
+                if desired_format["adapter_format"] in (
+                    "ase",
+                    "pymatgen",
+                    "aiida_structuredata",
+                ):
+                    # output is not a file, but a proxy Python class
+                    func = getattr(self, f"_get_via_{desired_format['adapter_format']}")
+                    output = func(output, desired_format=desired_format["final_format"])
+                encoding = "utf-8"
 
-        data = base64.b64encode(output.encode(encoding)).decode()
+                # Specifically for CIF: v1.x CIF needs to be in "latin-1" formatting
+                if desired_format["ext"] == ".cif":
+                    encoding = "latin-1"
 
-        self.download_button.value = self._download_button_format.format(
-            disabled="", encoding=encoding, data=data, filename=filename
-        )
+                filename = (
+                    f"optimade_structure_{self.structure.id}{desired_format['ext']}"
+                )
+
+                if isinstance(output, str):
+                    output = output.encode(encoding)
+                data = base64.b64encode(output).decode()
+            except Warning as warn:
+                self.download_button.value = self._download_button_format.format(
+                    disabled="disabled", encoding="", data="", filename=""
+                )
+                warnings.warn(OptimadeClientWarning(warn))
+            except Exception as exc:
+                self.download_button.value = self._download_button_format.format(
+                    disabled="disabled", encoding="", data="", filename=""
+                )
+                if isinstance(exc, exceptions.OptimadeClientError):
+                    raise exc
+                # Else wrap the exception to make sure to log it.
+                raise exceptions.OptimadeClientError(exc)
+            else:
+                self.download_button.value = self._download_button_format.format(
+                    disabled="", encoding=encoding, data=data, filename=filename
+                )
+
+    @staticmethod
+    def _get_via_pymatgen(
+        structure_molecule: Union[pymatgenStructure, pymatgenMolecule],
+        desired_format: str,
+    ) -> str:
+        """Use pymatgen.[Structure,Molecule].to() method"""
+        molecule_only_formats = ["xyz", "pdb"]
+        structure_only_formats = ["xsf", "cif"]
+        if desired_format in molecule_only_formats and not isinstance(
+            structure_molecule, pymatgenMolecule
+        ):
+            raise exceptions.WrongPymatgenType(
+                f"Converting to '{desired_format}' format is only possible with a pymatgen."
+                f"Molecule, instead got {type(structure_molecule)}"
+            )
+        if desired_format in structure_only_formats and not isinstance(
+            structure_molecule, pymatgenStructure
+        ):
+            raise exceptions.WrongPymatgenType(
+                f"Converting to '{desired_format}' format is only possible with a pymatgen."
+                f"Structure, instead got {type(structure_molecule)}."
+            )
+
+        return structure_molecule.to(fmt=desired_format)
+
+    @staticmethod
+    def _get_via_ase(atoms: aseAtoms, desired_format: str) -> Union[str, bytes]:
+        """Use ase.Atoms.write() method"""
+        with tempfile.NamedTemporaryFile(mode="w+b") as temp_file:
+            atoms.write(temp_file.name, format=desired_format)
+            res = temp_file.read()
+        return res
 
     def freeze(self):
         """Disable widget"""

--- a/aiidalab_optimade/warnings.py
+++ b/aiidalab_optimade/warnings.py
@@ -1,0 +1,20 @@
+from typing import Tuple, Any
+
+from aiidalab_optimade.logger import LOGGER
+
+
+class OptimadeClientWarning(Warning):
+    """Top-most warning class for OPTIMADE Client"""
+
+    def __init__(self, *args: Tuple[Any]):
+        LOGGER.warning(
+            "%s warned.\nWarning message: %s\nAbout this warning: %s",
+            args[0].__class__.__name__
+            if args and isinstance(args[0], Exception)
+            else self.__class__.__name__,
+            str(args[0]) if args else "",
+            args[0].__doc__
+            if args and isinstance(args[0], Exception)
+            else self.__doc__,
+        )
+        super().__init__(*args)

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,9 +1,10 @@
-optimade~=0.7
+optimade~=0.8
 requests~=2.23
-jupyterlab~=2.0
+jupyterlab~=2.1
 ipywidgets~=7.5
 nglview~=2.7
 numpy~=1.18
 pandas~=1.0
+ase~=3.19
 appmode
 voila

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,9 @@ setup(
         "nglview~=2.7",
         "numpy~=1.18",
         "pandas~=1.0",
+        "ase~=3.19",
         "appmode",
+        "voila",
     ],
     extras_require={"aiidalab": AIIDALAB, "dev": DEV, "testing": TESTING},
     classifiers=[


### PR DESCRIPTION
Closes #30 

Add functionality to convert an OPTIMADE structure to another format _via_ ASE (`ase.Atoms.write()`) or pymatgen (`pymatgen.[Structure,Molecule].to()`).
Hence `ase` and `pymatgen` are also added to the list of install requirements.

Formats added in this PR:
- XYZ (ASE, pymatgen.Molecule)
- XSF (ASE, pymatgen.Structure)
- WIEN2k struct (ASE)
- VASP POSCAR (ASE)
- Quantum ESPRESSO in (ASE)

Formats extended in this PR:
- CIF (ASE, pymatgen.Structure)
- PDB (ASE, pymatgen.Molecule)

As is evident from the lists above, pymatgen is very selective to _only_ convert to certain formats depending on whether we have a pymatgen `Molecule` or `Structure`. This has currently been dealt with by emitting a warning (in the log) and disabling the "Download" button.

All of the conversion is done a bit more "safely" now as well, since it's all in a try/except block, where any `Exception` (or `Warning`) is caught, logged, and the "Download" button is disabled, `else` good-to-go.

[Test on binder (APP mode)](https://mybinder.org/v2/gh/CasperWA/aiidalab-optimade/close_30_new-export-formats?urlpath=%2Fapps%2FOPTIMADE_general.ipynb)
[Test on binder (Voilà)](https://mybinder.org/v2/gh/CasperWA/aiidalab-optimade/close_30_new-export-formats?urlpath=%2Fvoila%2Frender%2FOPTIMADE_general.ipynb)
