### PR TITLE
Catch requests connection errors and timeouts

### DIFF
--- a/aiidalab_optimade/logger.py
+++ b/aiidalab_optimade/logger.py
@@ -77,7 +77,7 @@ class OutputLogger(ipw.Output):
             "min_height": "160px",
             "max_height": "240px",
             "border": "1px solid black",
-            "overflow_y": "auto",  # "Internal" scrolling
+            "overflow": "hidden auto",  # "Internal" scrolling
         }
         super().__init__(layout=layout)
 

--- a/aiidalab_optimade/query_filter.py
+++ b/aiidalab_optimade/query_filter.py
@@ -205,7 +205,7 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
                     "errors": {
                         "msg": "CLIENT: Connection error or timeout.",
                         "url": link,
-                        "Exception": exc,
+                        "Exception": repr(exc),
                     }
                 }
             except JSONDecodeError as exc:
@@ -213,7 +213,7 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
                     "errors": {
                         "msg": "CLIENT: Could not decode response to JSON.",
                         "url": link,
-                        "Exception": exc,
+                        "Exception": repr(exc),
                     }
                 }
             return response

--- a/aiidalab_optimade/subwidgets/provider_database.py
+++ b/aiidalab_optimade/subwidgets/provider_database.py
@@ -21,6 +21,7 @@ from aiidalab_optimade.utils import (
     handle_errors,
     perform_optimade_query,
     validate_api_version,
+    TIMEOUT_SECONDS,
 )
 
 
@@ -274,9 +275,26 @@ class ProviderImplementationChooser(  # pylint: disable=too-many-instance-attrib
         # If a complete link is provided, use it straight up
         if link is not None:
             try:
-                response = requests.get(link).json()
-            except json.JSONDecodeError:
-                response = {"errors": {}}
+                response = requests.get(link, timeout=TIMEOUT_SECONDS).json()
+            except (
+                requests.exceptions.ConnectTimeout,
+                requests.exceptions.ConnectionError,
+            ) as exc:
+                response = {
+                    "errors": {
+                        "msg": "CLIENT: Connection error or timeout.",
+                        "url": link,
+                        "Exception": exc,
+                    }
+                }
+            except json.JSONDecodeError as exc:
+                response = {
+                    "errors": {
+                        "msg": "CLIENT: Could not decode response to JSON.",
+                        "url": link,
+                        "Exception": exc,
+                    }
+                }
         else:
             response = perform_optimade_query(
                 base_url=self.provider.base_url,
@@ -287,7 +305,7 @@ class ProviderImplementationChooser(  # pylint: disable=too-many-instance-attrib
         msg = handle_errors(response)
         if msg:
             self.error_or_status_messages.value = msg
-            raise QueryError(remove_target=False)
+            raise QueryError(msg=msg, remove_target=False)
 
         # Check implementation API version
         msg = validate_api_version(
@@ -297,11 +315,12 @@ class ProviderImplementationChooser(  # pylint: disable=too-many-instance-attrib
             self.error_or_status_messages.value = (
                 f"{msg}.<br>The provider will be removed."
             )
-            raise QueryError(remove_target=True)
+            raise QueryError(msg=msg, remove_target=True)
 
         LOGGER.debug(
-            "First attempt (in /links): Found implementations:\n%s",
-            str(json.dumps(response.get("data", []), indent=2)),
+            "First attempt for %r (in /links): Found implementations:\n%r",
+            self.provider.name,
+            json.dumps(response.get("data", []), indent=2),
         )
         # Return all implementations of type "child"
         implementations = [
@@ -324,7 +343,7 @@ class ProviderImplementationChooser(  # pylint: disable=too-many-instance-attrib
                 self.error_or_status_messages.value = (
                     f"{msg}.<br>The provider will be removed."
                 )
-                raise QueryError(remove_target=True)
+                raise QueryError(msg=msg, remove_target=True)
 
             if new_response:
                 LOGGER.debug(

--- a/aiidalab_optimade/subwidgets/provider_database.py
+++ b/aiidalab_optimade/subwidgets/provider_database.py
@@ -284,7 +284,7 @@ class ProviderImplementationChooser(  # pylint: disable=too-many-instance-attrib
                     "errors": {
                         "msg": "CLIENT: Connection error or timeout.",
                         "url": link,
-                        "Exception": exc,
+                        "Exception": repr(exc),
                     }
                 }
             except json.JSONDecodeError as exc:
@@ -292,7 +292,7 @@ class ProviderImplementationChooser(  # pylint: disable=too-many-instance-attrib
                     "errors": {
                         "msg": "CLIENT: Could not decode response to JSON.",
                         "url": link,
-                        "Exception": exc,
+                        "Exception": repr(exc),
                     }
                 }
         else:

--- a/aiidalab_optimade/utils.py
+++ b/aiidalab_optimade/utils.py
@@ -87,7 +87,7 @@ def perform_optimade_query(  # pylint: disable=too-many-arguments,too-many-branc
             "errors": {
                 "msg": "CLIENT: Connection error or timeout.",
                 "url": complete_url,
-                "Exception": exc,
+                "Exception": repr(exc),
             }
         }
 
@@ -143,12 +143,13 @@ def get_versioned_base_url(base_url: str) -> str:
             return ""
 
     for version in _VERSION_PARTS:
+        timeout_seconds = 5
         versioned_base_url = (
             base_url + version[1:] if base_url.endswith("/") else base_url + version
         )
         try:
             response = requests.get(
-                f"{versioned_base_url}/info", timeout=TIMEOUT_SECONDS
+                f"{versioned_base_url}/info", timeout=timeout_seconds
             )
         except (
             requests.exceptions.ConnectTimeout,
@@ -242,7 +243,7 @@ def get_structures_schema(base_url: str) -> dict:
             "errors": {
                 "msg": "CLIENT: Connection error or timeout.",
                 "url": url_path,
-                "Exception": exc,
+                "Exception": repr(exc),
             }
         }
     else:

--- a/aiidalab_optimade/utils.py
+++ b/aiidalab_optimade/utils.py
@@ -79,9 +79,16 @@ def perform_optimade_query(  # pylint: disable=too-many-arguments,too-many-branc
     complete_url = f"{url_path}?{url_query}"
     try:
         response = requests.get(complete_url, timeout=TIMEOUT_SECONDS)
-    except Exception as exc:  # pylint: disable=broad-except
+    except (
+        requests.exceptions.ConnectTimeout,
+        requests.exceptions.ConnectionError,
+    ) as exc:
         return {
-            "errors": f"CLIENT: The URL cannot be opened: {complete_url}. Exception: {exc}"
+            "errors": {
+                "msg": "CLIENT: Connection error or timeout.",
+                "url": complete_url,
+                "Exception": exc,
+            }
         }
 
     try:
@@ -139,8 +146,18 @@ def get_versioned_base_url(base_url: str) -> str:
         versioned_base_url = (
             base_url + version[1:] if base_url.endswith("/") else base_url + version
         )
-        if requests.get(f"{versioned_base_url}/info").status_code == 200:
-            return versioned_base_url
+        try:
+            response = requests.get(
+                f"{versioned_base_url}/info", timeout=TIMEOUT_SECONDS
+            )
+        except (
+            requests.exceptions.ConnectTimeout,
+            requests.exceptions.ConnectionError,
+        ):
+            continue
+        else:
+            if response.status_code == 200:
+                return versioned_base_url
 
     return ""
 
@@ -215,18 +232,38 @@ def get_structures_schema(base_url: str) -> dict:
         base_url + endpoint[1:] if base_url.endswith("/") else base_url + endpoint
     )
 
-    response = requests.get(url_path)
+    try:
+        response = requests.get(url_path, timeout=TIMEOUT_SECONDS)
+    except (
+        requests.exceptions.ConnectTimeout,
+        requests.exceptions.ConnectionError,
+    ) as exc:
+        return {
+            "errors": {
+                "msg": "CLIENT: Connection error or timeout.",
+                "url": url_path,
+                "Exception": exc,
+            }
+        }
+    else:
+        if response.status_code != 200:
+            return {
+                "errors": {
+                    "msg": "CLIENT: Not a successful 200 response.",
+                    "url": url_path,
+                    "status": response.status_code,
+                }
+            }
 
-    if response.status_code != 200:
+        properties = response.get("data", {}).get("properties", {})
+        output_fields_by_json = response.get("output_fields_by_format", {}).get(
+            "json", []
+        )
+        for field in output_fields_by_json:
+            if field in properties:
+                result[field] = properties[field]
+
         return result
-
-    properties = response.get("data", {}).get("properties", {})
-    output_fields_by_json = response.get("output_fields_by_format", {}).get("json", [])
-    for field in output_fields_by_json:
-        if field in properties:
-            result[field] = properties[field]
-
-    return result
 
 
 def handle_errors(response: dict) -> str:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -37,7 +37,7 @@ def test_exmpl_not_in_list():
         },
     )
 
-    materials_cloud = (
+    mcloud = (
         "Materials Cloud",
         {
             "name": "Materials Cloud",
@@ -48,7 +48,19 @@ def test_exmpl_not_in_list():
         },
     )
 
+    odbx = (
+        "open database of xtals",
+        {
+            "name": "open database of xtals",
+            "description": "A public database of crystal structures mostly derived from ab initio "
+            "structure prediction from the group of Dr Andrew Morris at the University of "
+            "Birmingham https://ajm143.github.io",
+            "base_url": "https://optimade.odbx.science/v0",
+            "homepage": "https://odbx.science",
+        },
+    )
+
     list_of_database_providers = utils.get_list_of_valid_providers()
 
     assert exmpl not in list_of_database_providers
-    assert materials_cloud in list_of_database_providers
+    assert mcloud in list_of_database_providers or odbx in list_of_database_providers


### PR DESCRIPTION
Fixes #41 

This was found due to connection errors and timeouts when Materials Cloud was down, and fixed within the same time period.

All invocations of `requests.<HTTP method>` have been wrapped in a try/except that catches `requests.exceptions.ConnectionError` and `requests.exceptions.ConnectTimeout` and returns an appropriate error message.
They have all had their `timout` parameter set as well to the value of `aiidalab_optimade.utils.TIMEOUT_SECONDS`.

Also, other error messages have been updated for better error reporting and logging.