### PR TITLE
Introduce filter ranges (for nsites and nelements)

### DIFF
--- a/OPTIMADE_general.ipynb
+++ b/OPTIMADE_general.ipynb
@@ -16,18 +16,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8943950cc6564fada719f94162d6397b",
+       "model_id": "eb6ce49431104ed787478a75c603232c",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "HeaderDescription(children=(Image(value=b'\\x89PNG\\r\\n\\x1a\\n\\x00\\x00\\x00\\rIHDR\\x00\\x00\\t\\x1e\\x00\\x00\\x03K\\x08\\x…"
+       "_ColormakerRegistry()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "eff01e6ce24e44c18dda08bf792aaef2",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HeaderDescription(children=(ReportLogger(value=\"<input type='hidden' id='report_log' value='%3Cdetails%3E%0A++…"
       ]
      },
      "metadata": {},

--- a/aiidalab_optimade/exceptions.py
+++ b/aiidalab_optimade/exceptions.py
@@ -70,9 +70,9 @@ class ParserError(OptimadeClientError):
 
     def __init__(
         self,
+        msg: str = None,
         field: str = None,
         value: Any = None,
-        msg: str = None,
         extras: Union[Sequence[Tuple[str, Any]], Tuple[str, Any]] = None,
     ):
         self.field = field if field is not None else "General (no field given)"
@@ -97,7 +97,7 @@ class BadResource(ImplementationError):
     """Resource does not fulfill requirements from supported version of the OPTIMADE API spec"""
 
     def __init__(  # pylint: disable=too-many-arguments
-        self, resource: Resource, fields: Union[List[str], str] = None, msg: str = None,
+        self, resource: Resource, msg: str = None, fields: Union[List[str], str] = None
     ):
         self.resource = resource
         self.fields = fields if fields is not None else []

--- a/aiidalab_optimade/query_filter.py
+++ b/aiidalab_optimade/query_filter.py
@@ -22,6 +22,7 @@ from aiidalab_optimade.utils import (
     perform_optimade_query,
     handle_errors,
     TIMEOUT_SECONDS,
+    check_entry_properties,
 )
 
 
@@ -202,7 +203,14 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
         if db_base_url not in self.__cached_ranges:
             self.__cached_ranges[db_base_url] = {}
 
-        for response_field in ("nsites", "nelements"):
+        sortable_fields = check_entry_properties(
+            base_url=db_base_url,
+            entry_endpoint="structures",
+            properties=["nsites", "nelements"],
+            checks=["sort"],
+        )
+
+        for response_field in sortable_fields:
             if response_field in self.__cached_ranges[db_base_url]:
                 # Use cached values
                 continue

--- a/aiidalab_optimade/subwidgets/filter_inputs.py
+++ b/aiidalab_optimade/subwidgets/filter_inputs.py
@@ -1,8 +1,10 @@
 import re
-from typing import Dict, List, Union, Tuple
+from typing import Dict, List, Union, Tuple, Callable, Any
 
 import ipywidgets as ipw
 import traitlets
+
+from optimade.models.utils import CHEMICAL_SYMBOLS
 
 from aiidalab_optimade.exceptions import ParserError
 from aiidalab_optimade.logger import LOGGER
@@ -15,18 +17,17 @@ class FilterTabs(ipw.Tab):
     """Separate filter inputs into tabs"""
 
     def __init__(self, **kwargs):
-
-        self.sections = (
+        sections: Tuple[Tuple[str, FilterTabSection]] = (
             ("Basic", FilterInputs()),
             # ("Advanced", ipw.HTML("This input tab has not yet been implemented.")),
             ("Raw", FilterRaw()),
         )
 
         super().__init__(
-            children=tuple(_[1] for _ in self.sections),
+            children=tuple(_[1] for _ in sections),
             layout={"width": "auto", "height": "auto"},
         )
-        for index, title in enumerate([_[0] for _ in self.sections]):
+        for index, title in enumerate([_[0] for _ in sections]):
             self.set_title(index, title)
 
     def freeze(self):
@@ -49,27 +50,47 @@ class FilterTabs(ipw.Tab):
 
     def collect_value(self) -> str:
         """Collect inputs to a single OPTIMADE filter query string"""
-        active_widget = self.sections[self.selected_index][1]
+        active_widget = self.children[self.selected_index]
         if not isinstance(active_widget, ipw.HTML):
             return active_widget.collect_value()
         return ""
 
     def on_submit(self, callback, remove=False):
         """(Un)Register a callback to handle text submission"""
-        active_widget = self.sections[self.selected_index][1]
-        if not isinstance(active_widget, ipw.HTML):
-            active_widget.on_submit(callback=callback, remove=remove)
+        for section_widget in self.children:
+            section_widget.on_submit(callback=callback, remove=remove)
+
+    def update_range_filters(self, data: Dict[str, dict]):
+        """Update filter widgets with a range (e.g., IntRangeSlider) according to `data`"""
+        for section_widget in self.children:
+            section_widget.range_nx = data
 
 
-class FilterRaw(ipw.VBox):
+class FilterTabSection(ipw.VBox):
+    """Base class for a filter tab section"""
+
+    range_nx = traitlets.Dict(allow_none=True)
+
+    @traitlets.observe("range_nx")
+    def update_ranged_inputs(self, change: dict):
+        """Update ranged inputs' min/max values"""
+
+    def collect_value(self) -> str:
+        """Collect inputs to a single OPTIMADE filter query string"""
+
+    def on_submit(self, callback, remove=False):
+        """(Un)Register a callback to handle user input submission"""
+
+
+class FilterRaw(FilterTabSection):
     """Filter inputs for raw input"""
 
     def __init__(self, **kwargs):
         self.inputs = [
-            FilterText(
-                field="Filter",
+            FilterInput(
+                description="Filter",
                 hint="Raw 'filter' query string ...",
-                field_width="50px",
+                description_width="50px",
             )
         ]
 
@@ -77,91 +98,111 @@ class FilterRaw(ipw.VBox):
 
     def reset(self):
         """Reset widget"""
-        for text in self.inputs:
-            text.reset()
+        for user_input in self.inputs:
+            user_input.reset()
 
     def freeze(self):
         """Disable widget"""
-        for text in self.inputs:
-            text.freeze()
+        for user_input in self.inputs:
+            user_input.freeze()
 
     def unfreeze(self):
         """Activate widget (in its current state)"""
-        for text in self.inputs:
-            text.unfreeze()
+        for user_input in self.inputs:
+            user_input.unfreeze()
 
     def collect_value(self) -> str:
         """Collect inputs to a single OPTIMADE filter query string"""
         filter_ = self.inputs[0]
-        return filter_.user_input.strip()
+        return filter_.get_user_input.strip()
 
     def on_submit(self, callback, remove=False):
-        """(Un)Register a callback to handle text submission"""
-        for text in self.inputs:
-            text.on_submit(callback=callback, remove=remove)
+        """(Un)Register a callback to handle user input submission"""
+        for user_input in self.inputs:
+            user_input.on_submit(callback=callback, remove=remove)
 
 
-class FilterText(ipw.HBox):
-    """Combination of HTML and Text for filter inputs"""
+class FilterInput(ipw.HBox):
+    """Combination of HTML and input widget for filter inputs
 
-    def __init__(self, field: str, hint: str = None, field_width: str = None, **kwargs):
-        _field_width = field_width if field_width is not None else "170px"
-        description = ipw.HTML(field, layout=ipw.Layout(width=_field_width))
-        self.text_input = ipw.Text(layout=ipw.Layout(width="100%"))
-        if hint:
-            self.text_input.placeholder = hint
+    :param kwargs: Keyword arguments passed on to `input_widget`
+    """
+
+    def __init__(
+        self,
+        description: str,
+        input_widget: Callable = None,
+        hint: str = None,
+        description_width: str = None,
+        **kwargs,
+    ):
+        _description_width = (
+            description_width if description_width is not None else "170px"
+        )
+        description = ipw.HTML(description, layout={"width": _description_width})
+
+        _layout = {"width": "100%"}
+        self.input_widget = (
+            input_widget(layout=_layout, **kwargs)
+            if input_widget is not None
+            else ipw.Text(layout=_layout)
+        )
+
+        if hint and isinstance(self.input_widget, ipw.widgets.widget_string._String):
+            self.input_widget.placeholder = hint
+
         super().__init__(
-            children=[description, self.text_input],
-            layout=ipw.Layout(width="auto"),
-            **kwargs,
+            children=[description, self.input_widget], layout=ipw.Layout(width="auto"),
         )
 
     @property
-    def user_input(self):
-        """The Text.value"""
-        return self.text_input.value
+    def get_user_input(self):
+        """The Widget.value"""
+        return self.input_widget.value
 
     def reset(self):
         """Reset widget"""
-        self.text_input.disabled = False
+        with self.hold_trait_notifications():
+            self.input_widget.value = ""
+        self.input_widget.disabled = False
 
     def freeze(self):
         """Disable widget"""
-        self.text_input.disabled = True
+        self.input_widget.disabled = True
 
     def unfreeze(self):
-        """Activate widget (in its current state)
-        This is the same as self.reset() in this case,
-        since we want to keep the already typed in filter inputs.
-        """
-        self.reset()
+        """Activate widget (in its current state)"""
+        self.input_widget.disabled = False
 
     def on_submit(self, callback, remove=False):
         """(Un)Register a callback to handle text submission"""
-        self.text_input._submission_callbacks.register_callback(  # pylint: disable=protected-access
-            callback, remove=remove
-        )
+        if isinstance(self.input_widget, ipw.Text):
+            self.input_widget._submission_callbacks.register_callback(  # pylint: disable=protected-access
+                callback, remove=remove
+            )
 
 
 class FilterInputParser:
     """Parse user input for filters"""
 
-    def parse(self, key: str, value: str) -> str:
+    def __default__(self, value: Any) -> Any:  # pylint: disable=no-self-use
+        """Default parsing fallback function"""
+        if isinstance(value, str):
+            value = value.strip()
+        return value
+
+    def parse(self, key: str, value: Any) -> Any:
         """Reroute to self.<key>(value)"""
         func = getattr(self, key, None)
         if func is None:
             return self.__default__(value)
         return func(value)
 
-    def __default__(self, value: str) -> str:  # pylint: disable=no-self-use
-        """Default parsing fallback function"""
-        return value
-
     @staticmethod
     def chemical_formula_descriptive(value: str) -> str:
         """Chemical formula descriptive is a free form input"""
         value = re.sub('"', "", value)
-        return f'"{value}"'
+        return f'"{value}"' if value else ""
 
     @staticmethod
     def dimension_types(value: str) -> str:
@@ -185,11 +226,11 @@ class FilterInputParser:
             # wrappers = ("[", "]")
         else:
             raise ParserError(
+                "Wrong input. Should be e.g. (4.1, 0, 0) (0, 4.1, 0) (0, 0, 4.1)",
                 "lattica_vectors",
                 value,
-                msg="Wrong input. Should be e.g. (4.1, 0, 0) (0, 4.1, 0) (0, 0, 4.1)",
             )
-        raise ParserError("lattice_vectors", value, msg="Not yet implemented.")
+        raise ParserError("Not yet implemented.", "lattice_vectors", value)
         # for vector in re.finditer(f"{wrappers[0]}.*{wrappers[1]}", value):
         #     vector.
 
@@ -215,9 +256,9 @@ class FilterInputParser:
             match_operator = [_ for _ in match_operator if _]
             if len(match_operator) != 1:
                 raise ParserError(
+                    "Multiple values given with operators.",
                     field,
                     value,
-                    msg="Multiple values given with operators.",
                     extras=("match_operator", match_operator,),
                 )
             number = re.findall(r"[0-9]+", value)[0]
@@ -227,37 +268,52 @@ class FilterInputParser:
             match_no_operator = [_ for _ in match_no_operator if _]
             if len(match_no_operator) != 1:
                 raise ParserError(
+                    "Multiple values given, must be an integer, "
+                    "either with or without an operator prefixed.",
                     field,
                     value,
-                    msg="Multiple values given, must be an integer, "
-                    "either with or without an operator prefixed.",
                     extras=("match_no_operator", match_no_operator,),
                 )
             result = re.sub(r"\s*", "", match_no_operator[0])
             return f"={result}"
         raise ParserError(
+            "Not proper input. Should be, e.g., '>=3' or '5'",
             field,
             value,
-            msg="Not proper input. Should be, e.g., '>=3' or '5'",
             extras=[
                 ("match_operator", match_operator),
                 ("match_no_operator", match_no_operator),
             ],
         )
 
-    def nsites(self, value: str) -> str:
-        """OPTIONAL operator with integer value"""
-        return self.operator_and_integer("nsites", value)
+    @staticmethod
+    def ranged_int(field: str, value: Tuple[int, int]) -> str:
+        """Turn IntRangeSlider widget value into OPTIMADE filter string"""
+        LOGGER.debug("ranged_int: Received value %r for field %r", value, field)
 
-    def nelements(self, value: str) -> str:
-        """OPTIONAL operator with integer value"""
-        return self.operator_and_integer("nelements", value)
+        low, high = value
+        if low == high:
+            # Exactly N of property
+            res = f"={low}"
+        else:
+            # Range of property
+            res = [f">={low}", f"<={high}"]
+
+        LOGGER.debug("ranged_int: Concluded the response is %r", res)
+
+        return res
+
+    def nsites(self, value: Tuple[int, int]) -> Union[List[str], str]:
+        """Operator with integer values"""
+        return self.ranged_int("nsites", value)
+
+    def nelements(self, value: Tuple[int, int]) -> Union[List[str], str]:
+        """Operator with integer values"""
+        return self.ranged_int("nelements", value)
 
     @staticmethod
     def elements(value: str) -> str:
         """Check against optimade-python-tools list of elememnts"""
-        from optimade.models.utils import CHEMICAL_SYMBOLS
-
         results = []
         symbols = re.findall(r",?\s*[\"']?\w*[\"']?,?\s*", value)
         for symbol in symbols:
@@ -267,13 +323,13 @@ class FilterInputParser:
             escaped_symbol = escaped_symbol.capitalize()
             if escaped_symbol not in CHEMICAL_SYMBOLS:
                 raise ParserError(
-                    "elements", value, msg=f"{escaped_symbol} is not a valid element."
+                    f"{escaped_symbol} is not a valid element.", "elements", value
                 )
             results.append(escaped_symbol)
         return ",".join([f'"{symbol}"' for symbol in results])
 
 
-class FilterInputs(ipw.VBox):
+class FilterInputs(FilterTabSection):
     """Filter inputs in a single widget"""
 
     provider_section = traitlets.List()
@@ -284,10 +340,19 @@ class FilterInputs(ipw.VBox):
             [
                 (
                     "chemical_formula_descriptive",
-                    ("Chemical Formula", "e.g., (H2O)2 Na"),
+                    {"description": "Chemical Formula", "hint": "e.g., (H2O)2 Na"},
                 ),
-                ("elements", ("Elements", "H, O, Cl, ...")),
-                ("nelements", ("Number of Elements", "e.g., 3 or >=5")),
+                ("elements", {"description": "Elements", "hint": "H, O, Cl, ..."}),
+                (
+                    "nelements",
+                    {
+                        "description": "Number of Elements",
+                        "input_widget": ipw.IntRangeSlider,
+                        "min": 0,
+                        "max": len(CHEMICAL_SYMBOLS),
+                        "value": (0, len(CHEMICAL_SYMBOLS)),
+                    },
+                ),
             ],
         ),
         (
@@ -295,22 +360,32 @@ class FilterInputs(ipw.VBox):
             [
                 (
                     "dimension_types",
-                    (
-                        "Dimensions",
-                        "0: Molecule, 3: Bulk, (Not supported: 1: Wire, 2: Planar)",
-                    ),
+                    {
+                        "description": "Dimensions",
+                        "hint": "0: Molecule, 3: Bulk, (Not supported: 1: Wire, 2: Planar)",
+                    },
                 ),
-                # (
-                #     "lattice_vectors",
-                #     (
-                #         "Lattice Vectors",
-                #         "e.g., (4.1, 0, 0), (0, 4.1, 0), (0, 0, 4.1)",
-                #     ),
-                # ),
-                ("nsites", ("Number of Sites", "e.g., >5")),
+                (
+                    "nsites",
+                    {
+                        "description": "Number of Sites",
+                        "input_widget": ipw.IntRangeSlider,
+                        "min": 0,
+                        "max": 10000,
+                        "value": (0, 10000),
+                    },
+                ),
             ],
         ),
-        ("Provider specific", [("id", ("Provider ID", "NB! Will take precedence"))]),
+        (
+            "Provider specific",
+            [
+                (
+                    "id",
+                    {"description": "Provider ID", "hint": "NB! Will take precedence"},
+                )
+            ],
+        ),
     ]
 
     FIELD_MAP = {"dimension_types": "NOT dimension_types"}
@@ -326,7 +401,7 @@ class FilterInputs(ipw.VBox):
     }
 
     def __init__(self, **kwargs):
-        self.query_fields: Dict[str, FilterText] = {}
+        self.query_fields: Dict[str, FilterInput] = {}
         self._layout = ipw.Layout(width="auto")
 
         sections = [
@@ -340,57 +415,124 @@ class FilterInputs(ipw.VBox):
 
     def reset(self):
         """Reset widget"""
-        for text in self.query_fields.values():
-            text.reset()
+        for user_input in self.query_fields.values():
+            user_input.reset()
 
     def freeze(self):
         """Disable widget"""
-        for text in self.query_fields.values():
-            text.freeze()
+        for user_input in self.query_fields.values():
+            user_input.freeze()
 
     def unfreeze(self):
         """Activate widget (in its current state)"""
-        for text in self.query_fields.values():
-            text.unfreeze()
+        for user_input in self.query_fields.values():
+            user_input.unfreeze()
+
+    @traitlets.observe("range_nx")
+    def update_ranged_inputs(self, change: dict):
+        """Update ranged inputs' min/max values"""
+        ranges = change["new"]
+        if not ranges or ranges is None:
+            return
+
+        for field, config in ranges.items():
+            if field not in self.query_fields:
+                raise ParserError(
+                    field=field,
+                    value="N/A",
+                    extras=[
+                        ("config", config),
+                        ("self.query_fields.keys", self.query_fields.keys()),
+                    ],
+                    msg="Provided field is unknown. Can not update range for unknown field.",
+                )
+
+            widget = self.query_fields[field].input_widget
+            cached_value: Tuple[int, int] = widget.value
+            for attr in ("min", "max"):
+                if attr in config:
+                    try:
+                        new_value = int(config[attr])
+                    except (TypeError, ValueError) as exc:
+                        raise ParserError(
+                            field=field,
+                            value=cached_value,
+                            extras=[("attr", attr), ("config[attr]", config[attr])],
+                            msg=f"Could not cast config[attr] to int. Exception: {exc!s}",
+                        )
+                    else:
+                        LOGGER.debug(
+                            "Setting %s for %s to %d.\nWidget now: %r",
+                            attr,
+                            field,
+                            new_value,
+                            widget,
+                        )
+                        setattr(widget, attr, new_value)
+                        LOGGER.debug("Updated widget:\n%r", widget)
 
     def update_provider_section(self):
         """Update the provider input section from the chosen provider"""
         # schema = get_structures_schema(self.base_url)
 
     def new_section(
-        self, title: str, inputs: List[Dict[str, Union[str, Tuple]]]
+        self, title: str, inputs: List[Tuple[str, Union[str, Dict[str, Any]]]]
     ) -> ipw.VBox:
         """Generate a new filter section"""
         header = ipw.HTML(f"<br><strong>{title}</strong>")
-        text_inputs = []
-        for text_input in inputs:
-            text = text_input[1]
-            if isinstance(text, tuple):
-                new_input = FilterText(field=text[0], hint=text[1])
+        user_inputs = []
+        for user_input in inputs:
+            input_config = user_input[1]
+            if isinstance(input_config, dict):
+                new_input = FilterInput(**input_config)
             else:
-                new_input = FilterText(field=text)
-            text_inputs.append(new_input)
+                new_input = FilterInput(field=input_config)
+            user_inputs.append(new_input)
 
-            self.query_fields[text_input[0]] = new_input
+            self.query_fields[user_input[0]] = new_input
 
-        text_inputs.insert(0, header)
-        return ipw.VBox(children=text_inputs, layout=self._layout)
+        user_inputs.insert(0, header)
+        return ipw.VBox(children=user_inputs, layout=self._layout)
 
     def collect_value(self) -> str:
         """Collect inputs to a single OPTIMADE filter query string"""
         parser = FilterInputParser()
 
-        result = " AND ".join(
-            [
-                f"{self.FIELD_MAP.get(field, field)}{self.OPERATOR_MAP[field]}"
-                f"{parser.parse(field, text.user_input)}"
-                for field, text in self.query_fields.items()
-                if text.user_input != ""
-            ]
-        )
-        return re.sub("'", '"', result)
+        result = []
+        for field, user_input in self.query_fields.items():
+            # if not user_input.get_user_input:
+            #     # If there is no input, skip field
+            #     continue
+
+            parsed_value = parser.parse(field, user_input.get_user_input)
+            if not parsed_value:
+                # Also, if the parsed value results in an empty value, skip field
+                continue
+
+            if isinstance(parsed_value, (list, tuple, set)):
+                result.extend(
+                    [
+                        f"{self.FIELD_MAP.get(field, field)}{self.OPERATOR_MAP[field]}{value}"
+                        for value in parsed_value
+                    ]
+                )
+            elif isinstance(parsed_value, str):
+                result.append(
+                    f"{self.FIELD_MAP.get(field, field)}{self.OPERATOR_MAP[field]}{parsed_value}"
+                )
+            else:
+                raise ParserError(
+                    field=field,
+                    value=user_input.get_user_input,
+                    msg="Parsed value was neither a list, tuple, set nor str and it wasn't empty "
+                    "or None.",
+                    extras=("parsed_value", parsed_value),
+                )
+
+        result = " AND ".join(result)
+        return re.sub("'", '"', result)  # OPTIMADE Filter grammar only supports " not '
 
     def on_submit(self, callback, remove=False):
-        """(Un)Register a callback to handle text submission"""
-        for text in self.query_fields.values():
-            text.on_submit(callback=callback, remove=remove)
+        """(Un)Register a callback to handle user input submission"""
+        for user_input in self.query_fields.values():
+            user_input.on_submit(callback=callback, remove=remove)

--- a/aiidalab_optimade/utils.py
+++ b/aiidalab_optimade/utils.py
@@ -32,6 +32,7 @@ def perform_optimade_query(  # pylint: disable=too-many-arguments,too-many-branc
     base_url: str,
     endpoint: str = None,
     filter: Union[dict, str] = None,  # pylint: disable=redefined-builtin
+    sort: str = None,
     response_format: str = None,
     response_fields: str = None,
     email_address: str = None,
@@ -58,6 +59,9 @@ def perform_optimade_query(  # pylint: disable=too-many-arguments,too-many-branc
         else:
             raise TypeError("'filter' must be either a dict or a str")
 
+    if sort is not None:
+        queries["sort"] = sort
+
     if response_format is None:
         response_format = "json"
     queries["response_format"] = response_format
@@ -77,6 +81,7 @@ def perform_optimade_query(  # pylint: disable=too-many-arguments,too-many-branc
     # Make query - get data
     url_query = urlencode(queries)
     complete_url = f"{url_path}?{url_query}"
+    LOGGER.debug("Performing OPTIMADE query:\n%s", complete_url)
     try:
         response = requests.get(complete_url, timeout=TIMEOUT_SECONDS)
     except (

--- a/aiidalab_optimade/utils.py
+++ b/aiidalab_optimade/utils.py
@@ -32,7 +32,7 @@ def perform_optimade_query(  # pylint: disable=too-many-arguments,too-many-branc
     base_url: str,
     endpoint: str = None,
     filter: Union[dict, str] = None,  # pylint: disable=redefined-builtin
-    sort: str = None,
+    sort: Union[str, List[str]] = None,
     response_format: str = None,
     response_fields: str = None,
     email_address: str = None,
@@ -61,7 +61,10 @@ def perform_optimade_query(  # pylint: disable=too-many-arguments,too-many-branc
             raise TypeError("'filter' must be either a dict or a str")
 
     if sort is not None:
-        queries["sort"] = sort
+        if isinstance(sort, str):
+            queries["sort"] = sort
+        else:
+            queries["sort"] = ",".join(sort)
 
     if response_format is None:
         response_format = "json"
@@ -125,8 +128,8 @@ def fetch_providers(providers_url: str = None) -> list:
 
 _VERSION_PARTS = [
     f"/v{__optimade_version__.split('.')[0]}",  # major
-    f"/v{'.'.join(__optimade_version__.split('.')[:2])}",  # minor
-    f"/v{__optimade_version__}",  # patch
+    f"/v{'.'.join(__optimade_version__.split('.')[:2])}",  # major.minor
+    f"/v{__optimade_version__}",  # major.minor.patch
 ]
 
 


### PR DESCRIPTION
Closes #34 

This PR implements some infrastructure to have other than simple text inputs for filter values.
Specifically, the ipywidget `IntRangeSlider` is used for `nelements` and `nsites`.

Furthermore, the boundaries are dynamically updated for each implementation according to the min/max number of elements or sites there are in it. This is then cached and reused if another database is chosen before returning to the first one again to minimize the number of requests that are made.

Note: One may consider to use cookies to store some of this data on the client side in between sessions and speed up the app even more.

A possibility to check for "sortability" and "presence" of entry-endpoint resource properties is also added, where the endpoint `/info/<entry-endpoint>` is analyzed.

PR: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/CasperWA/aiidalab-optimade/close_34_filter-ranges?urlpath=%2Fvoila%2Frender%2FOPTIMADE_general.ipynb)