### PR TITLE
Use periodic table widget

### DIFF
--- a/OPTIMADE Client.ipynb
+++ b/OPTIMADE Client.ipynb
@@ -22,13 +22,11 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "eb6ce49431104ed787478a75c603232c",
+       "model_id": "fa8d5fed5612439eb41ba72e4865c3df",
        "version_major": 2,
        "version_minor": 0
       },
-      "text/plain": [
-       "_ColormakerRegistry()"
-      ]
+      "text/plain": []
      },
      "metadata": {},
      "output_type": "display_data"
@@ -36,7 +34,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "eff01e6ce24e44c18dda08bf792aaef2",
+       "model_id": "248ff428d6f64205bf08e42179b47b86",
        "version_major": 2,
        "version_minor": 0
       },
@@ -72,13 +70,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2d3ac030cdf6485683d5b2b6d41a9a45",
+       "model_id": "52dbfbd90c2341d2bcea60105284ac70",
        "version_major": 2,
        "version_minor": 0
       },
@@ -96,13 +94,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f487029ac38b404aa17481f8c881b3f3",
+       "model_id": "1b7cc3b7ba634a9d9e6f91b4fec334ef",
        "version_major": 2,
        "version_minor": 0
       },
@@ -120,13 +118,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
+   "execution_count": 5,
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "570112f2c3e248de887cdccaf8c39091",
+       "model_id": "5c41c44c31194980b946964546cc9b81",
        "version_major": 2,
        "version_minor": 0
       },
@@ -140,7 +140,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "361a51d138bb4c4887da62a0cdf76f8a",
+       "model_id": "c1204af5b58740be9f5293195577dfce",
        "version_major": 2,
        "version_minor": 0
       },
@@ -154,7 +154,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "854f77f2025141559df74ee6803a7411",
+       "model_id": "8f00a400c162477f9d6de9efb22b77e6",
        "version_major": 2,
        "version_minor": 0
       },
@@ -188,9 +188,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.7.5 64-bit ('jupyter': virtualenv)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python37564bitjupytervirtualenvb49a49bc685c45e9b5700717fed9db83"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/aiidalab_optimade/subwidgets/__init__.py
+++ b/aiidalab_optimade/subwidgets/__init__.py
@@ -1,6 +1,7 @@
 # pylint: disable=undefined-variable
 from .filter_inputs import *
 from .output_summary import *
+from .periodic_table import *
 from .provider_database import *
 from .results import *
 
@@ -8,6 +9,7 @@ from .results import *
 __all__ = (
     filter_inputs.__all__  # noqa
     + output_summary.__all__  # noqa
+    + periodic_table.__all__  # noqa
     + provider_database.__all__  # noqa
     + results.__all__  # noqa
 )

--- a/aiidalab_optimade/subwidgets/filter_inputs.py
+++ b/aiidalab_optimade/subwidgets/filter_inputs.py
@@ -4,9 +4,9 @@ from typing import Dict, List, Union, Tuple, Callable, Any
 import ipywidgets as ipw
 import traitlets
 
-from widget_periodictable import PTableWidget
-
 from optimade.models.utils import CHEMICAL_SYMBOLS
+
+from widget_periodictable import PTableWidget
 
 from aiidalab_optimade.exceptions import ParserError
 from aiidalab_optimade.logger import LOGGER
@@ -165,13 +165,15 @@ class FilterInput(ipw.HBox):
         except AttributeError:
             try:
                 # Periodic Table
-                res = [
-                    (element, state)
-                    for element, state in zip(
-                        self.input_widget.selected_elements,
-                        self.input_widget.selected_states,
-                    )
-                ]
+                LOGGER.debug(
+                    "Trying if periodic table. input_widget.selected_elements = %r",
+                    getattr(
+                        self.input_widget,
+                        "selected_elements",
+                        "Attribute does not exist",
+                    ),
+                )
+                res = self.input_widget.selected_elements
             except AttributeError:
                 raise ParserError(
                     msg="Correct attribute can not be found to retrieve widget value",
@@ -332,11 +334,11 @@ class FilterInputParser:
         return self.ranged_int("nelements", value)
 
     @staticmethod
-    def elements(value: List[Tuple[str, int]]) -> Union[List[str], List[Tuple[str]]]:
+    def elements(value: Dict[str, int]) -> Union[List[str], List[Tuple[str]]]:
         """Extract included and excluded elements"""
         include = []
         exclude = []
-        for element, state in value:
+        for element, state in value.items():
             if state == 0:
                 # Include
                 include.append(element)

--- a/aiidalab_optimade/subwidgets/filter_inputs.py
+++ b/aiidalab_optimade/subwidgets/filter_inputs.py
@@ -387,6 +387,7 @@ class FilterInputs(FilterTabSection):
                         "states": 2,  # Included/Excluded
                         "unselected_color": "#5096f1",  # Blue
                         "selected_colors": ["#66BB6A", "#EF5350"],  # Green, red
+                        "border_color": "#000000",  # Black
                     },
                 ),
                 (

--- a/aiidalab_optimade/subwidgets/periodic_table.py
+++ b/aiidalab_optimade/subwidgets/periodic_table.py
@@ -15,6 +15,7 @@ class PeriodicTable(ipw.VBox):
         layout = kwargs.pop("layout", None)
         if layout is None:
             layout = ipw.Layout(width="auto")
+        self._disabled = kwargs.pop("disabled", False)
 
         self.select_any_all = ipw.Checkbox(
             value=False,
@@ -37,3 +38,29 @@ class PeriodicTable(ipw.VBox):
         LOGGER.debug("PeriodicTable: Select ANY or ALL = %r", self.select_any_all.value)
 
         return self.select_any_all.value, self.ptable.selected_elements.copy()
+
+    @property
+    def disabled(self) -> None:
+        """Disable widget"""
+        return self._disabled
+
+    @disabled.setter
+    def disabled(self, value: bool) -> None:
+        """Disable widget"""
+        if not isinstance(value, bool):
+            raise TypeError("disabled must be a boolean")
+
+        self.select_any_all.disabled = self.ptable.disabled = value
+
+    def reset(self):
+        """Reset widget"""
+        self.select_any_all.value = False
+        self.ptable.selected_elements = {}
+
+    def freeze(self):
+        """Disable widget"""
+        self.disabled = True
+
+    def unfreeze(self):
+        """Activate widget (in its current state)"""
+        self.disabled = False

--- a/aiidalab_optimade/subwidgets/periodic_table.py
+++ b/aiidalab_optimade/subwidgets/periodic_table.py
@@ -1,0 +1,37 @@
+import ipywidgets as ipw
+
+from widget_periodictable import PTableWidget
+
+from aiidalab_optimade.logger import LOGGER
+
+
+__all__ = ("PeriodicTable",)
+
+
+class PeriodicTable(ipw.VBox):
+    """Wrapper-widget for PTableWidget"""
+
+    def __init__(self, **kwargs):
+        layout = kwargs.pop("layout", None)
+        if layout is None:
+            layout = ipw.Layout(width="auto")
+
+        self.select_any_all = ipw.Checkbox(
+            value=False, description="Exclude all unselected elements",
+        )
+        self.ptable = PTableWidget(**kwargs)
+
+        super().__init__(
+            children=(self.select_any_all, self.ptable), layout=layout,
+        )
+
+    @property
+    def value(self) -> dict:
+        """Return value for wrapped PTableWidget"""
+        LOGGER.debug(
+            "PeriodicTable: PTableWidget.selected_elements = %r",
+            self.ptable.selected_elements,
+        )
+        LOGGER.debug("PeriodicTable: Select ANY or ALL = %r", self.select_any_all.value)
+
+        return self.select_any_all.value, self.ptable.selected_elements.copy()

--- a/aiidalab_optimade/subwidgets/periodic_table.py
+++ b/aiidalab_optimade/subwidgets/periodic_table.py
@@ -17,12 +17,14 @@ class PeriodicTable(ipw.VBox):
             layout = ipw.Layout(width="auto")
 
         self.select_any_all = ipw.Checkbox(
-            value=False, description="Exclude all unselected elements",
+            value=False,
+            description="Exclude all unselected elements",
         )
         self.ptable = PTableWidget(**kwargs)
 
         super().__init__(
-            children=(self.select_any_all, self.ptable), layout=layout,
+            children=(self.select_any_all, self.ptable),
+            layout=layout,
         )
 
     @property

--- a/aiidalab_optimade/summary.py
+++ b/aiidalab_optimade/summary.py
@@ -89,14 +89,6 @@ class DownloadChooser(ipw.HBox):
         ),
         ("Protein Data Bank (.pdb)", {"ext": ".pdb", "adapter_format": "pdb"}),
         (
-            "Crystallographic Information File v1.0 [via ASE] (.cif)",
-            {"ext": ".cif", "adapter_format": "ase", "final_format": "cif"},
-        ),
-        (
-            "Protein Data Bank [via ASE] (.pdb)",
-            {"ext": ".pdb", "adapter_format": "ase", "final_format": "proteindatabank"},
-        ),
-        (
             "XMol XYZ File [via ASE] (.xyz)",
             {"ext": ".xyz", "adapter_format": "ase", "final_format": "xyz"},
         ),

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -10,3 +10,6 @@ jupyter nbextension enable --py --sys-prefix nglview
 # Voilà
 jupyter nbextension enable --py --sys-prefix voila
 
+# Period Table
+jupyter nbextension enable --py --sys-prefix widget_periodictable
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ optimade~=0.11.0
 pandas~=1.1
 requests~=2.24
 voila~=0.1.23
+widget_periodictable~=2.1


### PR DESCRIPTION
Closes #48 

Use the Periodic Table widget from OSSCAR as input of "Elements".
Using "states" it can act as input for both including and excluding.

Issues left to solve:
- Update published version of widget (to PyPI) to newest develop version.
- Fix basic bugs in widget (trailing `;`, etc.)
- Allow changing the layout (being able to set HTML CSS width, height, etc.)