### PR TITLE
Update to v3.1.1

### DIFF
--- a/aiidalab_optimade/__init__.py
+++ b/aiidalab_optimade/__init__.py
@@ -18,4 +18,4 @@ __all__ = (
     "OptimadeStructureResultsWidget",
     "OptimadeSummaryWidget",
 )
-__version__ = "3.1.0"
+__version__ = "3.1.1"

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ DEV = ["pylint", "black", "pre-commit", "invoke"] + TESTING
 
 setup(
     name="aiidalab-optimade",
-    version="3.1.0",
+    version="3.1.1",
     packages=find_packages(),
     license="MIT Licence",
     author="The AiiDA Lab team",


### PR DESCRIPTION
**Updates**:
- Start in debug mode (by passing `debug` to `run.sh`) (#59).
- Put the result structures dropdown in a separate widget (#59).
  This is relevant for #57 in order to move it to the right side of the application (#59).
- If a structure with partial occupancies is selected, the ASE download options are removed.
  The added infrastructure allows the (re)addition of `pymatgen` support (#59).
- Disable child DB/implementations dropdown if exactly 0 or 1 child DBs/implementations are found.
  If a single implementation is found, automatically choose it immediately (#56).
- Cache first list of results for each provider's child DB after the first time they have been chosen (#55).

**Bug fixes**:
- Update `IntRangeSlider` widget values when selecting implementations (#59).
- Make all client-created OPTIMADE errors conform to the OPTIMADE error model (#59).
- Properly update child DB/implementations dropdown (#55).