### PR TITLE
Properly update and reset widgets

### DIFF
--- a/OPTIMADE_general.ipynb
+++ b/OPTIMADE_general.ipynb
@@ -67,6 +67,8 @@
     "summary = OptimadeSummaryWidget()\n",
     "\n",
     "_ = dlink((selector, 'database'), (filters, 'database'))\n",
+    "_ = dlink((filters, 'freeze_selector'), (selector, 'freeze_selector'))\n",
+    "_ = dlink((filters, 'unfreeze_selector'), (selector, 'unfreeze_selector'))\n",
     "_ = dlink((selector, 'database'), (results, 'base_url'), transform=lambda database: getattr(database[1], 'base_url', None) )\n",
     "_ = dlink((filters, 'optimade_filter'), (results, 'optimade_filter'))\n",
     "_ = dlink((filters, 'structures_response'), (results, 'new_searched_response'))\n",

--- a/OPTIMADE_general.ipynb
+++ b/OPTIMADE_general.ipynb
@@ -72,6 +72,7 @@
     "_ = dlink((selector, 'database'), (results, 'base_url'), transform=lambda database: getattr(database[1], 'base_url', None) )\n",
     "_ = dlink((filters, 'optimade_filter'), (results, 'optimade_filter'))\n",
     "_ = dlink((filters, 'structures_response'), (results, 'new_searched_response'))\n",
+    "_ = dlink((filters, 'reset_results'), (results, 'reset_results'))\n",
     "_ = dlink((results, 'freeze_filters'), (filters, 'freeze_filters'))\n",
     "_ = dlink((results, 'unfreeze_filters'), (filters, 'unfreeze_filters'))\n",
     "_ = dlink((results, 'structure'), (summary, 'entity'))\n",

--- a/aiidalab_optimade/informational.py
+++ b/aiidalab_optimade/informational.py
@@ -164,9 +164,7 @@ class OptimadeClientFAQ(ipw.Accordion):
   <li>The provider has implemented an unsupported version</li>
   <li>The provider has supplied a link that could not be reached</li>
 </ul>
-<p style="line-height:1.5;font-size:14px;">
-Please go to <a href="https://github.com/Materials-Consortia/providers" target="_blank">the Materials-Consortia list of providers repository</a> to update the provider in question's details.
-</p>""",
+<p style="line-height:1.5;font-size:14px;">Please go to <a href="https://github.com/Materials-Consortia/providers" target="_blank">the Materials-Consortia list of providers repository</a> to update the provider in question's details.</p>""",
         },
         {
             "Q": "When I choose a provider, why can I not find any databases?",
@@ -176,28 +174,28 @@ Please go to <a href="https://github.com/Materials-Consortia/providers" target="
   <li>The implementation is of an unsupported version</li>
   <li>The implementation could not be reached</li>
 </ul>
-<p style="line-height:1.5;font-size:14px;">
-An implementation may also be removed upon choosing it. This is do to OPTIMADE API version incompatibility between the implementation and this client.
-</p>""",
+<p style="line-height:1.5;font-size:14px;">An implementation may also be removed upon choosing it. This is do to OPTIMADE API version incompatibility between the implementation and this client.</p>""",
         },
         {
             "Q": "I know a database hosts X number of structures, why can I only find Y?",
-            "A": f"""<p style="line-height:1.5;font-size:14px;">
-All searches (including the raw input search) will be pre-processed prior to sending the query.
+            "A": f"""<p style="line-height:1.5;font-size:14px;">All searches (including the raw input search) will be pre-processed prior to sending the query.
 This is done to ensure the best experience when using the client.
 Specifically, all structures with <code>"assemblies"</code> and <code>"unknown_positions"</code>
-in the <code>"structural_features"</code> property are excluded.
-</p>
-<p style="line-height:1.5;font-size:14px;">
-<code>"assemblies"</code> handling will be implemented at a later time.
-See <a href="{SOURCE_URL}issues/12" target="_blank">this issue</a> for more information.
-</p>
-<p style="line-height:1.5;font-size:14px;">
-<code>"unknown_positions"</code> may be handled later, however, since these structures present difficulties for viewing, it will not be prioritized.
-</p>
-<p style="line-height:1.5;font-size:14px;">
-Finally, a provider may choose to expose only a subset of their database.
-</p>""",
+in the <code>"structural_features"</code> property are excluded.</p>
+<p style="line-height:1.5;font-size:14px;"><code>"assemblies"</code> handling will be implemented at a later time.
+See <a href="{SOURCE_URL}issues/12" target="_blank">this issue</a> for more information.</p>
+<p style="line-height:1.5;font-size:14px;"><code>"unknown_positions"</code> may be handled later, however, since these structures present difficulties for viewing, it will not be prioritized.</p>
+<p style="line-height:1.5;font-size:14px;">Finally, a provider may choose to expose only a subset of their database.</p>""",
+        },
+        {
+            "Q": "Why is the number of downloadable formats changing?",
+            "A": """<p style="line-height:1.5;font-size:14px;">Currently, only two libraries are used to transform the OPTIMADE structure into other known data types:</p>
+<ul style="line-height:1.5;font-size:14px;">
+  <li>The <a href="https://github.com/Materials-Consortia/optimade-python-tools" target="_blank">OPTIMADE Python Tools</a> library</li>
+  <li>The <a href="https://wiki.fysik.dtu.dk/ase/index.html" target="_blank">Atomistic Simulation Environment (ASE)</a> library</li>
+</ul>
+<p style="line-height:1.5;font-size:14px;">ASE does not support transforming structures with partial occupancies, hence the options using ASE will be removed when such structures are chosen in the application.
+There are plans to also integrate <a href="https://pymatgen.org/" target="_blank">pymatgen</a>, however, the exact integration is still under design.</p>""",
         },
     ]
 

--- a/aiidalab_optimade/query_filter.py
+++ b/aiidalab_optimade/query_filter.py
@@ -305,23 +305,29 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
     @traitlets.observe("database")
     def _on_database_select(self, _):
         """Load chosen database"""
-        self.query_button.description = "Updating ... "
-        self.query_button.icon = "cog"
-        self.query_button.tooltip = "Please wait ..."
-        if (
-            self.database[1] is None
-            or getattr(self.database[1], "base_url", None) is None
-        ):
-            self.query_button.disabled = True
-            self.query_button.tooltip = "Search - No database chosen"
-            self.filters.freeze()
-        else:
-            self._set_intslider_ranges()
-            self.query_button.disabled = False
-            self.query_button.tooltip = "Search"
-            self.filters.unfreeze()
-        self.query_button.description = "Search"
-        self.query_button.icon = "search"
+        working_tooltip = "Please wait ..."
+
+        try:
+            # Wait until we're clear
+            self.freeze()
+
+            self.query_button.description = "Updating ... "
+            self.query_button.icon = "cog"
+            self.query_button.tooltip = working_tooltip
+            if (
+                self.database[1] is None
+                or getattr(self.database[1], "base_url", None) is None
+            ):
+                # Everything stays frozen
+                self.query_button.tooltip = "Search - No database chosen"
+            else:
+                self._set_intslider_ranges()
+                self.unfreeze()
+        finally:
+            self.query_button.description = "Search"
+            self.query_button.icon = "search"
+            if self.query_button.tooltip == working_tooltip:
+                self.query_button.tooltip = "Search"
 
     def freeze(self):
         """Disable widget"""

--- a/aiidalab_optimade/query_filter.py
+++ b/aiidalab_optimade/query_filter.py
@@ -253,6 +253,8 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
     optimade_filter = traitlets.Unicode("")
     freeze_filters = traitlets.Bool(False)
     unfreeze_filters = traitlets.Bool(False)
+    freeze_selector = traitlets.Bool(False)
+    unfreeze_selector = traitlets.Bool(False)
 
     def __init__(self, result_limit: int = None, **kwargs):
         self.page_limit = result_limit if result_limit else 10
@@ -302,6 +304,12 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
         with self.hold_trait_notifications():
             self.unfreeze_filters = False
 
+    @traitlets.observe("freeze_selector", "unfreeze_selector")
+    def _un_freeze_selector(self, change: dict):
+        """Reset traitlet"""
+        with self.hold_trait_notifications():
+            setattr(self, change["name"], False)
+
     @traitlets.observe("database")
     def _on_database_select(self, _):
         """Load chosen database"""
@@ -333,11 +341,13 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
         """Disable widget"""
         self.query_button.disabled = True
         self.filters.freeze()
+        self.freeze_selector = True
 
     def unfreeze(self):
         """Activate widget (in its current state)"""
         self.query_button.disabled = False
         self.filters.unfreeze()
+        self.unfreeze_selector = True
 
     def reset(self):
         """Reset widget"""

--- a/aiidalab_optimade/query_filter.py
+++ b/aiidalab_optimade/query_filter.py
@@ -47,6 +47,7 @@ class OptimadeStructureResultsWidget(  # pylint: disable=too-many-instance-attri
     optimade_filter = traitlets.Unicode("")
     freeze_filters = traitlets.Bool(False)
     unfreeze_filters = traitlets.Bool(False)
+    reset_results = traitlets.Bool(False)
 
     def __init__(self, result_limit: int = None, **kwargs):
         self.page_limit = result_limit if result_limit else 10
@@ -97,6 +98,14 @@ class OptimadeStructureResultsWidget(  # pylint: disable=too-many-instance-attri
         """Reset traitlet"""
         with self.hold_trait_notifications():
             setattr(self, change["name"], False)
+
+    @traitlets.observe("reset_results")
+    def _on_reset_results(self, change: dict):
+        """Reset widget"""
+        if change["new"]:
+            self.reset()
+        with self.hold_trait_notifications():
+            self.reset_results = False
 
     def freeze(self):
         """Disable widget"""
@@ -255,6 +264,7 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
     unfreeze_filters = traitlets.Bool(False)
     freeze_selector = traitlets.Bool(False)
     unfreeze_selector = traitlets.Bool(False)
+    reset_results = traitlets.Bool(False)
 
     def __init__(self, result_limit: int = None, **kwargs):
         self.page_limit = result_limit if result_limit else 10
@@ -304,8 +314,8 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
         with self.hold_trait_notifications():
             self.unfreeze_filters = False
 
-    @traitlets.observe("freeze_selector", "unfreeze_selector")
-    def _un_freeze_selector(self, change: dict):
+    @traitlets.observe("freeze_selector", "unfreeze_selector", "reset_results")
+    def _reset_traitlets(self, change: dict):
         """Reset traitlet"""
         with self.hold_trait_notifications():
             setattr(self, change["name"], False)
@@ -318,6 +328,9 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
         try:
             # Wait until we're clear
             self.freeze()
+
+            # Clear results dropdown
+            self.reset_results = True
 
             self.query_button.description = "Updating ... "
             self.query_button.icon = "cog"

--- a/aiidalab_optimade/query_provider.py
+++ b/aiidalab_optimade/query_provider.py
@@ -26,6 +26,8 @@ class OptimadeQueryProviderWidget(ipw.GridspecLayout):
         traitlets.Instance(LinksResourceAttributes, allow_none=True),
         default_value=("", None),
     )
+    freeze_selector = traitlets.Bool(False)
+    unfreeze_selector = traitlets.Bool(False)
 
     def __init__(self, embedded: bool = False, database_limit: int = None, **kwargs):
         database_limit = database_limit if database_limit and database_limit > 0 else 10
@@ -54,6 +56,22 @@ class OptimadeQueryProviderWidget(ipw.GridspecLayout):
             )
 
         ipw.dlink((self.chooser, "database"), (self, "database"))
+
+    @traitlets.observe("freeze_selector")
+    def _on_freeze_selector(self, change: dict):
+        """Using traitlet to freeze chooser"""
+        if change["new"]:
+            self.freeze()
+        with self.hold_trait_notifications():
+            self.freeze_selector = False
+
+    @traitlets.observe("unfreeze_selector")
+    def _on_unfreeze_selector(self, change: dict):
+        """Using traitlet to unfreeze chooser"""
+        if change["new"]:
+            self.unfreeze()
+        with self.hold_trait_notifications():
+            self.unfreeze_selector = False
 
     def freeze(self):
         """Disable widget"""


### PR DESCRIPTION
Fixes #61 

This PR introduces the following updates:
- Return Search button to normalcy always.
- Handle min/max-values of `IntRangeSlider` widgets update cases with any starting values.
- Freeze more of the user-changeable inputs while doing background actions.
- Reset the results dropdown when choosing a new database.
- Add FAQ about changing download dropdown.