### PR TITLE
Remove "factoring out results" commit

### DIFF
--- a/OPTIMADE_general.ipynb
+++ b/OPTIMADE_general.ipynb
@@ -55,27 +55,17 @@
     "    OptimadeLog,\n",
     "    OptimadeQueryProviderWidget,\n",
     "    OptimadeQueryFilterWidget,\n",
-    "    OptimadeStructureResultsWidget,\n",
     "    OptimadeSummaryWidget,\n",
     ")\n",
-    "from ipywidgets import dlink, GridspecLayout, HTML, VBox\n",
+    "from ipywidgets import dlink, GridspecLayout, HTML\n",
     "from IPython.display import display\n",
     "\n",
     "selector = OptimadeQueryProviderWidget()\n",
     "filters = OptimadeQueryFilterWidget()\n",
-    "results = OptimadeStructureResultsWidget()\n",
     "summary = OptimadeSummaryWidget()\n",
     "\n",
     "_ = dlink((selector, 'database'), (filters, 'database'))\n",
-    "_ = dlink((filters, 'freeze_selector'), (selector, 'freeze_selector'))\n",
-    "_ = dlink((filters, 'unfreeze_selector'), (selector, 'unfreeze_selector'))\n",
-    "_ = dlink((selector, 'database'), (results, 'base_url'), transform=lambda database: getattr(database[1], 'base_url', None) )\n",
-    "_ = dlink((filters, 'optimade_filter'), (results, 'optimade_filter'))\n",
-    "_ = dlink((filters, 'structures_response'), (results, 'new_searched_response'))\n",
-    "_ = dlink((filters, 'reset_results'), (results, 'reset_results'))\n",
-    "_ = dlink((results, 'freeze_filters'), (filters, 'freeze_filters'))\n",
-    "_ = dlink((results, 'unfreeze_filters'), (filters, 'unfreeze_filters'))\n",
-    "_ = dlink((results, 'structure'), (summary, 'entity'))\n",
+    "_ = dlink((filters, 'structure'), (summary, 'entity'))\n",
     "\n",
     "HeaderDescription()"
    ]
@@ -177,15 +167,15 @@
     }
    ],
    "source": [
-    "filters_header = HTML('<h3 style=\"margin-bottom:0px;padding-bottom:0px;\">Query</h3>')\n",
-    "results_header = HTML('<h3 style=\"margin-bottom:0px;padding-bottom:0px;\">Results</h3>')\n",
+    "display(HTML('<h2 style=\"margin-below:0px;padding-below:0px;\">Query</h2>'))\n",
+    "\n",
     "display(selector)\n",
     "\n",
-    "filters_results_summary = GridspecLayout(1, 31)\n",
-    "filters_results_summary[:, :16] = VBox(children=(filters_header, filters, results_header, results), layout={\"width\": \"100%\", \"height\": \"100%\"})\n",
-    "filters_results_summary[:, 17:] = VBox(children=(summary,), layout={\"width\": \"100%\", \"height\": \"100%\"})\n",
+    "filters_summary = GridspecLayout(1, 31)\n",
+    "filters_summary[:, :16] = filters\n",
+    "filters_summary[:, 17:] = summary\n",
     "\n",
-    "display(filters_results_summary)"
+    "display(filters_summary)"
    ]
   },
   {

--- a/aiidalab_optimade/__init__.py
+++ b/aiidalab_optimade/__init__.py
@@ -5,7 +5,7 @@ AiiDA Lab App that implements an OPTIMADE client
 """
 from .informational import OptimadeClientFAQ, HeaderDescription, OptimadeLog
 from .query_provider import OptimadeQueryProviderWidget
-from .query_filter import OptimadeQueryFilterWidget, OptimadeStructureResultsWidget
+from .query_filter import OptimadeQueryFilterWidget
 from .summary import OptimadeSummaryWidget
 
 
@@ -15,7 +15,6 @@ __all__ = (
     "OptimadeLog",
     "OptimadeQueryProviderWidget",
     "OptimadeQueryFilterWidget",
-    "OptimadeStructureResultsWidget",
     "OptimadeSummaryWidget",
 )
 __version__ = "3.1.2"

--- a/aiidalab_optimade/query_filter.py
+++ b/aiidalab_optimade/query_filter.py
@@ -98,20 +98,33 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
     @traitlets.observe("database")
     def _on_database_select(self, _):
         """Load chosen database"""
+        self.structure_drop.reset()
+
         if (
             self.database[1] is None
             or getattr(self.database[1], "base_url", None) is None
         ):
-            self.query_button.disabled = True
             self.query_button.tooltip = "Search - No database chosen"
-            self.filters.freeze()
+            self.freeze()
         else:
             self.offset = 0
-            self.query_button.disabled = False
-            self.query_button.tooltip = "Search"
-            self._set_intslider_ranges()
-            self.filters.unfreeze()
-        self.structure_drop.reset()
+            self.structure_page_chooser.reset()
+            try:
+                self.freeze()
+
+                self.query_button.description = "Updating ..."
+                self.query_button.icon = "cog"
+                self.query_button.tooltip = "Updating filters ..."
+
+                self._set_intslider_ranges()
+            except Exception as exc:
+                LOGGER.debug("Exception raised during setting IntSliderRanges: %r", exc)
+                raise
+            finally:
+                self.query_button.description = "Search"
+                self.query_button.icon = "search"
+                self.query_button.tooltip = "Search"
+                self.unfreeze()
 
     def _on_structure_select(self, change):
         """Update structure trait with chosen structure dropdown value"""

--- a/aiidalab_optimade/query_filter.py
+++ b/aiidalab_optimade/query_filter.py
@@ -33,27 +33,45 @@ DEFAULT_FILTER_VALUE = (
 )
 
 
-class OptimadeStructureResultsWidget(  # pylint: disable=too-many-instance-attributes
+class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
     ipw.VBox
 ):
-    """Dropdown of structure results including pager
+    """Structure search and import widget for OPTIMADE
 
     NOTE: Only supports offset-pagination at the moment.
     """
 
     structure = traitlets.Instance(Structure, allow_none=True)
-    new_searched_response = traitlets.Dict(allow_none=True)
-    base_url = traitlets.Unicode(allow_none=True)
-    optimade_filter = traitlets.Unicode("")
-    freeze_filters = traitlets.Bool(False)
-    unfreeze_filters = traitlets.Bool(False)
-    reset_results = traitlets.Bool(False)
+    database = traitlets.Tuple(
+        traitlets.Unicode(),
+        traitlets.Instance(LinksResourceAttributes, allow_none=True),
+    )
 
     def __init__(self, result_limit: int = None, **kwargs):
         self.page_limit = result_limit if result_limit else 10
         self.offset = 0
         self.__perform_query = True
+        self.__cached_ranges = {}
 
+        self.filter_header = ipw.HTML(
+            '<h4 style="margin:0px;padding:0px;">Apply filters</h4>'
+        )
+        self.filters = FilterTabs()
+        self.filters.freeze()
+        self.filters.on_submit(self.retrieve_data)
+
+        self.query_button = ipw.Button(
+            description="Search",
+            button_style="primary",
+            icon="search",
+            disabled=True,
+            tooltip="Search - No database chosen",
+        )
+        self.query_button.on_click(self.retrieve_data)
+
+        self.structures_header = ipw.HTML(
+            '<h4 style="margin-bottom:0px;padding:0px;">Results</h4>'
+        )
         self.structure_drop = StructureDropdown(disabled=True)
         self.structure_drop.observe(self._on_structure_select, names="value")
         self.error_or_status_messages = ipw.HTML("")
@@ -64,64 +82,36 @@ class OptimadeStructureResultsWidget(  # pylint: disable=too-many-instance-attri
         )
 
         super().__init__(
-            children=(
+            children=[
+                self.filter_header,
+                self.filters,
+                self.query_button,
+                self.structures_header,
                 self.structure_drop,
                 self.error_or_status_messages,
                 self.structure_page_chooser,
-            ),
-            layout={"width": "auto", "height": "auto", "margin": "0px 0px 20px 0px"},
+            ],
+            layout=ipw.Layout(width="auto", height="auto"),
             **kwargs,
         )
 
-    @traitlets.observe("new_searched_response")
-    def _new_first_page_results(self, change: dict):
-        """Update for newly retrieved first page results"""
-        response = change["new"]
-
-        if response:
-            # Update list of structures in dropdown widget
-            self._update_structures(response["data"])
-
-            # Update pageing
-            self.structure_page_chooser.set_pagination_data(
-                data_returned=response.get("meta", {}).get("data_returned", 0),
-                links_to_page=response.get("links", {}),
-                reset_cache=True,
-            )
-
-            self.unfreeze()
-        elif response is None:
-            self.reset()
-
-    @traitlets.observe("freeze_filters", "unfreeze_filters")
-    def _un_freeze_filters(self, change: dict):
-        """Reset traitlet"""
-        with self.hold_trait_notifications():
-            setattr(self, change["name"], False)
-
-    @traitlets.observe("reset_results")
-    def _on_reset_results(self, change: dict):
-        """Reset widget"""
-        if change["new"]:
-            self.reset()
-        with self.hold_trait_notifications():
-            self.reset_results = False
-
-    def freeze(self):
-        """Disable widget"""
-        self.structure_drop.freeze()
-        self.structure_page_chooser.freeze()
-
-    def unfreeze(self):
-        """Activate widget (in its current state)"""
-        self.structure_drop.unfreeze()
-        self.structure_page_chooser.unfreeze()
-
-    def reset(self):
-        """Reset widget"""
+    @traitlets.observe("database")
+    def _on_database_select(self, _):
+        """Load chosen database"""
+        if (
+            self.database[1] is None
+            or getattr(self.database[1], "base_url", None) is None
+        ):
+            self.query_button.disabled = True
+            self.query_button.tooltip = "Search - No database chosen"
+            self.filters.freeze()
+        else:
+            self.offset = 0
+            self.query_button.disabled = False
+            self.query_button.tooltip = "Search"
+            self._set_intslider_ranges()
+            self.filters.unfreeze()
         self.structure_drop.reset()
-        self.structure_page_chooser.reset()
-        self.error_or_status_messages.value = ""
 
     def _on_structure_select(self, change):
         """Update structure trait with chosen structure dropdown value"""
@@ -153,7 +143,11 @@ class OptimadeStructureResultsWidget(  # pylint: disable=too-many-instance-attri
             # Freeze and disable list of structures in dropdown widget
             # We don't want changes leading to weird things happening prior to the query ending
             self.freeze()
-            self.freeze_filters = True
+
+            # Update button text and icon
+            self.query_button.description = "Updating ... "
+            self.query_button.icon = "cog"
+            self.query_button.tooltip = "Please wait ..."
 
             # Query database
             response = self._query(offset_or_link)
@@ -171,204 +165,34 @@ class OptimadeStructureResultsWidget(  # pylint: disable=too-many-instance-attri
             )
 
         finally:
-            self.unfreeze()
-            self.unfreeze_filters = True
-
-    def _update_structures(self, data: list):
-        """Update structures dropdown from response data"""
-        structures = []
-
-        for entry in data:
-            structure = Structure(entry)
-
-            formula = structure.attributes.chemical_formula_descriptive
-            if formula is None:
-                formula = structure.attributes.chemical_formula_reduced
-            if formula is None:
-                formula = structure.attributes.chemical_formula_anonymous
-            if formula is None:
-                formula = structure.attributes.chemical_formula_hill
-            if formula is None:
-                raise BadResource(
-                    resource=structure,
-                    fields=[
-                        "chemical_formula_descriptive",
-                        "chemical_formula_reduced",
-                        "chemical_formula_anonymous",
-                        "chemical_formula_hill",
-                    ],
-                    msg="At least one of the following chemical formula fields "
-                    "should have a valid value",
-                )
-
-            entry_name = f"{formula} (id={structure.id})"
-            structures.append((entry_name, {"structure": structure}))
-
-        # Update list of structures in dropdown widget
-        self.structure_drop.set_options(structures)
-
-    def _query(self, link: str = None) -> dict:
-        """Query helper function"""
-        # If a complete link is provided, use it straight up
-        if link is not None:
-            try:
-                response = requests.get(link, timeout=TIMEOUT_SECONDS).json()
-            except (
-                requests.exceptions.ConnectTimeout,
-                requests.exceptions.ConnectionError,
-            ) as exc:
-                response = {
-                    "errors": {
-                        "msg": "CLIENT: Connection error or timeout.",
-                        "url": link,
-                        "Exception": repr(exc),
-                    }
-                }
-            except JSONDecodeError as exc:
-                response = {
-                    "errors": {
-                        "msg": "CLIENT: Could not decode response to JSON.",
-                        "url": link,
-                        "Exception": repr(exc),
-                    }
-                }
-            return response
-
-        # OPTIMADE queries
-        queries = {
-            "base_url": self.base_url,
-            "filter": self.optimade_filter,
-            "page_limit": self.page_limit,
-            "page_offset": self.offset,
-        }
-        LOGGER.debug(
-            "Parameters (excluding filter) sent to query util func: %s",
-            {key: value for key, value in queries.items() if key != "filter"},
-        )
-
-        return perform_optimade_query(**queries)
-
-
-class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
-    ipw.VBox
-):
-    """Structure search and import widget for OPTIMADE"""
-
-    structures_response = traitlets.Dict(allow_none=True)
-    database = traitlets.Tuple(
-        traitlets.Unicode(),
-        traitlets.Instance(LinksResourceAttributes, allow_none=True),
-    )
-    optimade_filter = traitlets.Unicode("")
-    freeze_filters = traitlets.Bool(False)
-    unfreeze_filters = traitlets.Bool(False)
-    freeze_selector = traitlets.Bool(False)
-    unfreeze_selector = traitlets.Bool(False)
-    reset_results = traitlets.Bool(False)
-
-    def __init__(self, result_limit: int = None, **kwargs):
-        self.page_limit = result_limit if result_limit else 10
-        self.__cached_ranges = {}
-
-        self.filter_header = ipw.HTML(
-            '<h4 style="margin:0px;padding:0px;">Apply filters</h4>'
-        )
-        self.filters = FilterTabs()
-        self.filters.freeze()
-        self.filters.on_submit(self.retrieve_data)
-
-        self.query_button = ipw.Button(
-            description="Search",
-            button_style="primary",
-            icon="search",
-            disabled=True,
-            tooltip="Search - No database chosen",
-        )
-        self.query_button.on_click(self.retrieve_data)
-        self.error_or_status_messages = ipw.HTML("")
-
-        super().__init__(
-            children=[
-                self.filter_header,
-                self.filters,
-                self.query_button,
-                self.error_or_status_messages,
-            ],
-            layout=ipw.Layout(width="auto", height="auto"),
-            **kwargs,
-        )
-
-    @traitlets.observe("freeze_filters")
-    def _on_freeze_filters(self, change: dict):
-        """Using traitlet to freeze filters"""
-        if change["new"]:
-            self.freeze()
-        with self.hold_trait_notifications():
-            self.freeze_filters = False
-
-    @traitlets.observe("unfreeze_filters")
-    def _on_unfreeze_filters(self, change: dict):
-        """Using traitlet to unfreeze filters"""
-        if change["new"]:
-            self.unfreeze()
-        with self.hold_trait_notifications():
-            self.unfreeze_filters = False
-
-    @traitlets.observe("freeze_selector", "unfreeze_selector", "reset_results")
-    def _reset_traitlets(self, change: dict):
-        """Reset traitlet"""
-        with self.hold_trait_notifications():
-            setattr(self, change["name"], False)
-
-    @traitlets.observe("database")
-    def _on_database_select(self, _):
-        """Load chosen database"""
-        working_tooltip = "Please wait ..."
-
-        try:
-            # Wait until we're clear
-            self.freeze()
-
-            # Clear results dropdown
-            self.reset_results = True
-
-            self.query_button.description = "Updating ... "
-            self.query_button.icon = "cog"
-            self.query_button.tooltip = working_tooltip
-            if (
-                self.database[1] is None
-                or getattr(self.database[1], "base_url", None) is None
-            ):
-                # Everything stays frozen
-                self.query_button.tooltip = "Search - No database chosen"
-            else:
-                self._set_intslider_ranges()
-                self.unfreeze()
-        finally:
             self.query_button.description = "Search"
             self.query_button.icon = "search"
-            if self.query_button.tooltip == working_tooltip:
-                self.query_button.tooltip = "Search"
+            self.query_button.tooltip = "Search"
+            self.unfreeze()
 
     def freeze(self):
         """Disable widget"""
         self.query_button.disabled = True
         self.filters.freeze()
-        self.freeze_selector = True
+        self.structure_drop.freeze()
+        self.structure_page_chooser.freeze()
 
     def unfreeze(self):
         """Activate widget (in its current state)"""
         self.query_button.disabled = False
         self.filters.unfreeze()
-        self.unfreeze_selector = True
+        self.structure_drop.unfreeze()
+        self.structure_page_chooser.unfreeze()
 
     def reset(self):
         """Reset widget"""
-        self.error_or_status_messages.value = ""
+        self.offset = 0
         with self.hold_trait_notifications():
             self.query_button.disabled = False
             self.query_button.tooltip = "Search - No database chosen"
             self.filters.reset()
+            self.structure_drop.reset()
+            self.structure_page_chooser.reset()
 
     def _set_intslider_ranges(self):
         """Update IntRangeSlider ranges according to chosen database
@@ -478,22 +302,6 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
                 }
             return response
 
-        # OPTIMADE queries
-        self._update_optimade_filter()
-        queries = {
-            "base_url": self.database[1].base_url,
-            "filter": self.optimade_filter,
-            "page_limit": self.page_limit,
-        }
-        LOGGER.debug(
-            "Parameters (excluding filter) sent to query util func: %s",
-            {key: value for key, value in queries.items() if key != "filter"},
-        )
-
-        return perform_optimade_query(**queries)
-
-    def _update_optimade_filter(self):
-        """Get OPTIMADE filter for collected inputs and update traitlet 'optimade_filter'"""
         # Avoid structures with null positions and with assemblies.
         add_to_filter = (
             'NOT structure_features HAS ANY "unknown_positions","assemblies"'
@@ -505,14 +313,61 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
             if optimade_filter
             else add_to_filter
         )
+        LOGGER.debug("Querying with filter: %s", optimade_filter)
 
-        LOGGER.debug("Update filter to: %r", optimade_filter)
-        self.optimade_filter = optimade_filter
+        # OPTIMADE queries
+        queries = {
+            "base_url": self.database[1].base_url,
+            "filter": optimade_filter,
+            "page_limit": self.page_limit,
+            "page_offset": self.offset,
+        }
+        LOGGER.debug(
+            "Parameters (excluding filter) sent to query util func: %s",
+            {key: value for key, value in queries.items() if key != "filter"},
+        )
+
+        return perform_optimade_query(**queries)
+
+    def _update_structures(self, data: list):
+        """Update structures dropdown from response data"""
+        structures = []
+
+        for entry in data:
+            structure = Structure(entry)
+
+            formula = structure.attributes.chemical_formula_descriptive
+            if formula is None:
+                formula = structure.attributes.chemical_formula_reduced
+            if formula is None:
+                formula = structure.attributes.chemical_formula_anonymous
+            if formula is None:
+                formula = structure.attributes.chemical_formula_hill
+            if formula is None:
+                raise BadResource(
+                    resource=structure,
+                    fields=[
+                        "chemical_formula_descriptive",
+                        "chemical_formula_reduced",
+                        "chemical_formula_anonymous",
+                        "chemical_formula_hill",
+                    ],
+                    msg="At least one of the following chemical formula fields "
+                    "should have a valid value",
+                )
+
+            entry_name = f"{formula} (id={structure.id})"
+            structures.append((entry_name, {"structure": structure}))
+
+        # Update list of structures in dropdown widget
+        self.structure_drop.set_options(structures)
 
     def retrieve_data(self, _):
         """Perform query and retrieve data"""
+        self.offset = 0
         try:
-            # We don't want changed inputs leading to weird things happening during querying
+            # Freeze and disable list of structures in dropdown widget
+            # We don't want changes leading to weird things happening prior to the query ending
             self.freeze()
 
             # Reset the error or status message
@@ -531,10 +386,19 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
                 self.error_or_status_messages.value = msg
                 raise QueryError(msg)
 
-            self.structures_response = response
+            # Update list of structures in dropdown widget
+            self._update_structures(response["data"])
+
+            # Update pageing
+            self.structure_page_chooser.set_pagination_data(
+                data_returned=response.get("meta", {}).get("data_returned", 0),
+                links_to_page=response.get("links", {}),
+                reset_cache=True,
+            )
 
         except QueryError:
-            self.structures_response = None
+            self.structure_drop.reset()
+            self.structure_page_chooser.reset()
 
         finally:
             self.query_button.description = "Search"

--- a/aiidalab_optimade/query_provider.py
+++ b/aiidalab_optimade/query_provider.py
@@ -26,8 +26,6 @@ class OptimadeQueryProviderWidget(ipw.GridspecLayout):
         traitlets.Instance(LinksResourceAttributes, allow_none=True),
         default_value=("", None),
     )
-    freeze_selector = traitlets.Bool(False)
-    unfreeze_selector = traitlets.Bool(False)
 
     def __init__(self, embedded: bool = False, database_limit: int = None, **kwargs):
         database_limit = database_limit if database_limit and database_limit > 0 else 10
@@ -56,22 +54,6 @@ class OptimadeQueryProviderWidget(ipw.GridspecLayout):
             )
 
         ipw.dlink((self.chooser, "database"), (self, "database"))
-
-    @traitlets.observe("freeze_selector")
-    def _on_freeze_selector(self, change: dict):
-        """Using traitlet to freeze chooser"""
-        if change["new"]:
-            self.freeze()
-        with self.hold_trait_notifications():
-            self.freeze_selector = False
-
-    @traitlets.observe("unfreeze_selector")
-    def _on_unfreeze_selector(self, change: dict):
-        """Using traitlet to unfreeze chooser"""
-        if change["new"]:
-            self.unfreeze()
-        with self.hold_trait_notifications():
-            self.unfreeze_selector = False
 
     def freeze(self):
         """Disable widget"""

--- a/aiidalab_optimade/subwidgets/results.py
+++ b/aiidalab_optimade/subwidgets/results.py
@@ -313,3 +313,9 @@ class ResultsPageChooser(ipw.HBox):  # pylint: disable=too-many-instance-attribu
         """Update offset from cache"""
         with self.hold_trait_notifications():
             self.page_offset = self._cache["page_offset"]
+
+    def silent_reset(self):
+        """Reset, but avoid updating page_offset or page_link"""
+        self.set_pagination_data(
+            data_returned=0, links_to_page=None, reset_cache=True,
+        )

--- a/aiidalab_optimade/summary.py
+++ b/aiidalab_optimade/summary.py
@@ -140,9 +140,8 @@ document.body.removeChild(link);" />
             )
         )
 
-        super().__init__(
-            children=(self.dropdown, self.download_button), layout={"width": "auto"}
-        )
+        self.children = (self.dropdown, self.download_button)
+        super().__init__(children=self.children, layout={"width": "auto"})
         self.reset()
 
         self.dropdown.observe(self._update_download_button, names="value")
@@ -192,8 +191,6 @@ document.body.removeChild(link);" />
             warnings.filterwarnings("error")
 
             try:
-                self.freeze()
-
                 output = getattr(
                     self.structure, f"as_{desired_format['adapter_format']}"
                 )
@@ -236,8 +233,6 @@ document.body.removeChild(link);" />
                 self.download_button.value = self._download_button_format.format(
                     disabled="", encoding=encoding, data=data, filename=filename
                 )
-            finally:
-                self.unfreeze()
 
     @staticmethod
     def _get_via_pymatgen(
@@ -274,16 +269,18 @@ document.body.removeChild(link);" />
 
     def freeze(self):
         """Disable widget"""
-        self.dropdown.disabled = True
+        for widget in self.children:
+            widget.disabled = True
 
     def unfreeze(self):
         """Activate widget (in its current state)"""
-        self.dropdown.disabled = False
+        for widget in self.children:
+            widget.disabled = False
 
     def reset(self):
         """Reset widget"""
         self.dropdown.index = 0
-        self.dropdown.disabled = True
+        self.freeze()
 
 
 class StructureViewer(ipw.VBox):


### PR DESCRIPTION
Factoring out the "results" widget has proven to result in an unstable application, where it's difficult to have reproducibility and there is an increased obscurity and obliqueness in the code. To the point where the desired behaviour is not achieved.

This PR effectively removes the commit, as well as a commit introducing cross-widget freeze/unfreeze control through traitlets. This should not be done.

As a retouch, the freezing/unfreezing of the filters and results upon choosing a database has been updated. 