### PR TITLE
Update to v3.1.3

### DIFF
--- a/aiidalab_optimade/__init__.py
+++ b/aiidalab_optimade/__init__.py
@@ -17,4 +17,4 @@ __all__ = (
     "OptimadeQueryFilterWidget",
     "OptimadeSummaryWidget",
 )
-__version__ = "3.1.2"
+__version__ = "3.1.3"

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ DEV = ["pylint", "black", "pre-commit", "invoke"] + TESTING
 
 setup(
     name="aiidalab-optimade",
-    version="3.1.2",
+    version="3.1.3",
     packages=find_packages(),
     license="MIT Licence",
     author="The AiiDA Lab team",


### PR DESCRIPTION
Reversion update.
All changes come from PR #65 (@CasperWA).

**Changes**:
- Revert commit 8780867, "Split results dropdown and page selector out".
- Revert commit bb68b22, "Freeze also selector dropdowns with filters".
- Properly freeze/unfreeze and reset filter widgets, search button, and results.
- Reset `IntRangeSlider` input filter widgets even for databases with no structures.
- "Soft" reset of results page chooser, due to over-eager traitlet event notifiers.