### PR TITLE
Handle updated links resources

### DIFF
--- a/aiidalab_optimade/informational.py
+++ b/aiidalab_optimade/informational.py
@@ -7,7 +7,10 @@ from urllib.parse import urlencode
 import ipywidgets as ipw
 
 from aiidalab_optimade.logger import LOGGER, WIDGET_HANDLER, REPORT_HANDLER
-from aiidalab_optimade.utils import __optimade_version__
+
+# from aiidalab_optimade.utils import __optimade_version__
+# Temporarily use another version for the information here
+__optimade_version__ = "1.0.0-rc.2"
 
 
 IMG_DIR = Path(__file__).parent.parent.joinpath("img")

--- a/aiidalab_optimade/utils.py
+++ b/aiidalab_optimade/utils.py
@@ -152,11 +152,10 @@ def get_versioned_base_url(base_url: str) -> str:
             if re.match(fr".+{version}/$", base_url):
                 return base_url[:-1]
             LOGGER.debug(
-                "Found version '%s' in base URL '%s', but not at the end of it.",
+                "Found version '%s' in base URL '%s', but not at the end of it. Will continue.",
                 version,
                 base_url,
             )
-            return ""
 
     for version in _VERSION_PARTS:
         timeout_seconds = 5

--- a/aiidalab_optimade/utils.py
+++ b/aiidalab_optimade/utils.py
@@ -11,7 +11,7 @@ from json import JSONDecodeError
 
 import requests
 
-from optimade.models import ProviderResource, OptimadeError
+from optimade.models import LinksResource, OptimadeError
 
 from aiidalab_optimade.exceptions import (
     ApiVersionError,
@@ -188,7 +188,7 @@ def get_list_of_valid_providers() -> List[Tuple[str, dict]]:
     res = []
 
     for entry in providers:
-        provider = ProviderResource(**entry)
+        provider = LinksResource(**entry)
 
         # Skip if "exmpl"
         if provider.id == "exmpl":
@@ -196,6 +196,14 @@ def get_list_of_valid_providers() -> List[Tuple[str, dict]]:
             continue
 
         attributes = provider.attributes
+
+        # Skip if not an 'external' link_type database
+        if attributes.link_type != "external":
+            LOGGER.debug(
+                "Skip: Links resource not an 'external' link_type, instead: %r",
+                attributes.link_type,
+            )
+            continue
 
         # Skip if there is no base URL
         if attributes.base_url is None:

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,5 +1,5 @@
-optimade~=0.8
-requests~=2.23
+optimade~=0.9.0
+requests~=2.24
 jupyterlab~=2.1
 ipywidgets~=7.5
 nglview~=2.7

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ setup(
     author="The AiiDA Lab team",
     python_requires=">=3.6",
     install_requires=[
-        "optimade~=0.8",
-        "requests~=2.23",
+        "optimade~=0.9.0",
+        "requests~=2.24",
         "jupyterlab~=2.1",
         "ipywidgets~=7.5",
         "nglview~=2.7",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,13 +12,14 @@ def test_fetch_providers_wrong_url():
 def test_fetch_providers_content():
     """Test known content in dict of database providers"""
     exmpl = {
-        "type": "provider",
+        "type": "links",
         "id": "exmpl",
         "attributes": {
             "name": "Example provider",
             "description": "Provider used for examples, not to be assigned to a real database",
-            "base_url": "https://example.com/optimade",
+            "base_url": "http://providers.optimade.org/index-metadbs/exmpl",
             "homepage": "https://example.com",
+            "link_type": "external",
         },
     }
 
@@ -34,6 +35,7 @@ def test_exmpl_not_in_list():
             "description": "Provider used for examples, not to be assigned to a real database",
             "base_url": "https://example.com/index/optimade",
             "homepage": "https://example.com",
+            "link_type": "external",
         },
     )
 
@@ -45,6 +47,7 @@ def test_exmpl_not_in_list():
             "sharing of resources in computational materials science",
             "base_url": "https://www.materialscloud.org/optimade/v0",
             "homepage": "https://www.materialscloud.org",
+            "link_type": "external",
         },
     )
 
@@ -57,6 +60,7 @@ def test_exmpl_not_in_list():
             "Birmingham https://ajm143.github.io",
             "base_url": "https://optimade.odbx.science/v0",
             "homepage": "https://odbx.science",
+            "link_type": "external",
         },
     )
 


### PR DESCRIPTION
Fixes #67 

This PR also updates the dependencies of `optimade` and `requests`, fixing the `optimade` dependency to the line of v0.9 patch updates (i.e., v0.9.x).