### PR TITLE
Up to v3.2.0

### DIFF
--- a/aiidalab_optimade/__init__.py
+++ b/aiidalab_optimade/__init__.py
@@ -17,4 +17,4 @@ __all__ = (
     "OptimadeQueryFilterWidget",
     "OptimadeSummaryWidget",
 )
-__version__ = "3.1.3"
+__version__ = "3.2.0"

--- a/setup.py
+++ b/setup.py
@@ -6,13 +6,13 @@ DEV = ["pylint", "black", "pre-commit", "invoke"] + TESTING
 
 setup(
     name="aiidalab-optimade",
-    version="3.1.3",
+    version="3.2.0",
     packages=find_packages(),
     license="MIT Licence",
     author="The AiiDA Lab team",
     python_requires=">=3.6",
     install_requires=[
-        "optimade~=0.9.0",
+        "optimade~=0.9.1",
         "requests~=2.24",
         "jupyterlab~=2.1",
         "ipywidgets~=7.5",


### PR DESCRIPTION
There is no longer support for combined index meta-databases and regular implementations.
The client now states to support OPTIMADE API v1.0.0-rc.2

**Changes**:
- Use new LinksResource schema (#74)
- Update dependencies (#74, #75)