### PR TITLE
Update to v1.0.0 of the OPTIMADE API specification

### DIFF
--- a/aiidalab_optimade/query_filter.py
+++ b/aiidalab_optimade/query_filter.py
@@ -480,7 +480,9 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
                 self._data_available = response.get("meta", {}).get(
                     "data_available", None
                 )
-            data_returned = response.get("meta", {}).get("data_returned", 0)
+            data_returned = response.get("meta", {}).get(
+                "data_returned", len(response.get("data", []))
+            )
             self.structure_page_chooser.set_pagination_data(
                 data_returned=data_returned,
                 data_available=self._data_available,

--- a/aiidalab_optimade/subwidgets/provider_database.py
+++ b/aiidalab_optimade/subwidgets/provider_database.py
@@ -572,7 +572,9 @@ class ProviderImplementationChooser(  # pylint: disable=too-many-instance-attrib
 
         # Get links, data_returned, and data_available
         links = response.get("links", {})
-        data_returned = response.get("meta", {}).get("data_returned", 0)
+        data_returned = response.get("meta", {}).get(
+            "data_returned", len(implementations)
+        )
         if data_returned > 0 and not implementations:
             # Most probably dealing with pre-v1.0.0-rc.2 implementations
             data_returned = 0

--- a/aiidalab_optimade/subwidgets/results.py
+++ b/aiidalab_optimade/subwidgets/results.py
@@ -65,7 +65,6 @@ class ResultsPageChooser(ipw.HBox):  # pylint: disable=too-many-instance-attribu
         self._cache = {}
         self.__last_page_offset: typing.Union[None, int] = None
         self.__last_page_number: typing.Union[None, int] = None
-        self._pageing_type: typing.Union[None, str] = None
         self._layout = ipw.Layout(width="auto")
 
         self._page_limit = page_limit
@@ -152,39 +151,6 @@ class ResultsPageChooser(ipw.HBox):  # pylint: disable=too-many-instance-attribu
         self.button_prev.disabled = self._cache["buttons"]["prev"]
         self.button_next.disabled = self._cache["buttons"]["next"]
         self.button_last.disabled = self._cache["buttons"]["last"]
-
-    @property
-    def pageing_type(self) -> typing.Union[str, None]:
-        """Get pageing type"""
-        return self._pageing_type
-
-    @pageing_type.setter
-    def pageing_type(self, value: str):
-        """Set pageing type
-
-        Must be one of SUPPORTED_PAGEING.
-        Can only be set once.
-        """
-        try:
-            value = str(value)
-        except (TypeError, ValueError):
-            raise InputError("pageing_type must be a string")
-
-        if self._pageing_type is not None:
-            raise InputError(
-                f"pageing_type can only be set once. It is set to {self._pageing_type!r}."
-            )
-
-        if value not in self.SUPPORTED_PAGEING:
-            raise InputError(
-                f"pageing_type must be one of: {list(self.SUPPORTED_PAGEING.keys())}"
-            )
-
-        self._pageing_type = value
-
-    def pageing_set(self) -> bool:
-        """Return whether pageing_type is set"""
-        return self.pageing_type is not None
 
     @property
     def data_returned(self) -> int:
@@ -402,18 +368,6 @@ class ResultsPageChooser(ipw.HBox):  # pylint: disable=too-many-instance-attribu
 
         self._update_cache(page_offset=offset, page_number=number)
 
-    def _determine_pageing(self):
-        """Determine and set the type of pageing"""
-        for url in self.pages_links.values():
-            parsed_url = urlparse(url)
-            query = parse_qs(parsed_url.query)
-            for pageing in self.SUPPORTED_PAGEING:
-                if pageing in query:
-                    self.pageing_type = pageing
-                    break
-            if self.pageing_type is not None:
-                break
-
     def set_pagination_data(
         self,
         data_returned: int = None,
@@ -428,8 +382,6 @@ class ResultsPageChooser(ipw.HBox):  # pylint: disable=too-many-instance-attribu
             self.data_available = data_available
         if links_to_page is not None:
             self.pages_links = links_to_page
-            if not self.pageing_set:
-                self._determine_pageing()
         if reset_cache:
             self._update_cache(**self.SUPPORTED_PAGEING)
             self.__last_page_offset = None

--- a/aiidalab_optimade/utils.py
+++ b/aiidalab_optimade/utils.py
@@ -23,7 +23,7 @@ from aiidalab_optimade.logger import LOGGER
 
 
 # Supported OPTIMADE spec versions
-__optimade_version__ = ["1.0.0-rc.2", "1.0.0-rc.1", "0.10.1"]
+__optimade_version__ = ["1.0.0", "1.0.0-rc.2", "1.0.0-rc.1", "0.10.1"]
 
 TIMEOUT_SECONDS = 10  # Seconds before URL query timeout is raised
 

--- a/aiidalab_optimade/utils.py
+++ b/aiidalab_optimade/utils.py
@@ -23,14 +23,14 @@ from aiidalab_optimade.logger import LOGGER
 
 
 # Supported OPTIMADE spec versions
-__optimade_version__ = ["1.0.0", "1.0.0-rc.2", "1.0.0-rc.1", "0.10.1"]
+__optimade_version__ = ["1.0.0", "1.0.0-rc.2", "1.0.0-rc.1", "0.10.1", "0.10.0"]
 
 TIMEOUT_SECONDS = 10  # Seconds before URL query timeout is raised
 
 PROVIDERS_URL = "https://providers.optimade.org/v1"
 
 
-def perform_optimade_query(  # pylint: disable=too-many-arguments,too-many-branches
+def perform_optimade_query(  # pylint: disable=too-many-arguments,too-many-branches,too-many-locals
     base_url: str,
     endpoint: str = None,
     filter: Union[dict, str] = None,  # pylint: disable=redefined-builtin
@@ -40,6 +40,7 @@ def perform_optimade_query(  # pylint: disable=too-many-arguments,too-many-branc
     email_address: str = None,
     page_limit: int = None,
     page_offset: int = None,
+    page_number: int = None,
 ) -> dict:
     """Perform query of database"""
     queries = {}
@@ -83,6 +84,9 @@ def perform_optimade_query(  # pylint: disable=too-many-arguments,too-many-branc
 
     if page_offset is not None:
         queries["page_offset"] = page_offset
+
+    if page_number is not None:
+        queries["page_number"] = page_number
 
     # Make query - get data
     url_query = urlencode(queries)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -50,7 +50,7 @@ def test_exmpl_not_in_list():
                 "name": "Materials Cloud",
                 "description": "A platform for Open Science built for seamless "
                 "sharing of resources in computational materials science",
-                "base_url": "https://www.materialscloud.org/optimade/v1",
+                "base_url": "https://www.materialscloud.org/optimade/v1.0.0",
                 "homepage": "https://www.materialscloud.org",
                 "link_type": "external",
             }
@@ -62,10 +62,10 @@ def test_exmpl_not_in_list():
         LinksResourceAttributes(
             **{
                 "name": "open database of xtals",
-                "description": "A public database of crystal structures mostly derived from ab initio "
-                "structure prediction from the group of Dr Andrew Morris at the University of "
-                "Birmingham https://ajm143.github.io",
-                "base_url": "https://optimade.odbx.science/v1",
+                "description": "A public database of crystal structures mostly derived from ab "
+                "initio structure prediction from the group of Dr Andrew Morris at the University "
+                "of Birmingham https://ajm143.github.io",
+                "base_url": "https://optimade.odbx.science/v1.0.0",
                 "homepage": "https://odbx.science",
                 "link_type": "external",
             }


### PR DESCRIPTION
This will update the client to support of [v1.0.0 of the OPTIMADE API specification](https://github.com/Materials-Consortia/OPTIMADE/blob/v1.0.0/optimade.rst).

Updating several things related to v1.0.0:
- Use `/versions` endpoint for new versioned base URL retrieval protocol
- Use updated `structure_features` keywords, while keeping support for the pre-v1.0.0 keywords for older implementations.

Other changes and updates:
- Support for `page_number`-pageing.
- Handle implementations that do not support `meta.data_returned`, i.e., does not return the number of data returned.
  Default/fallback is to return the "length" of `data`.