### PR TITLE
Update to v3.3.0

### DIFF
--- a/aiidalab_optimade/__init__.py
+++ b/aiidalab_optimade/__init__.py
@@ -17,4 +17,4 @@ __all__ = (
     "OptimadeQueryFilterWidget",
     "OptimadeSummaryWidget",
 )
-__version__ = "3.2.0"
+__version__ = "3.3.0"

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ DEV = ["pylint", "black", "pre-commit", "invoke"] + TESTING
 
 setup(
     name="aiidalab-optimade",
-    version="3.2.0",
+    version="3.3.0",
     packages=find_packages(),
     license="MIT Licence",
     author="The AiiDA Lab team",


### PR DESCRIPTION
The client now supports OPTIMADE API v1.0.0.

**Changes**:
- Retrieve versioned base URLs via `/versions` endpoint (#87)
- Add support for `page_number` pagination (#87)
- Support old _and_ new kind of `"links"` resources (#87)
- Update notebook name to be a nice name (OPTIMADE Client.ipynb) (#97)
- Several minor fixes (#87, #98)