### PR TITLE
Fallbacks for providers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 
 # logging
 optimade_client.log*
+
+# cache
+cached_providers.json

--- a/aiidalab_optimade/utils.py
+++ b/aiidalab_optimade/utils.py
@@ -186,13 +186,21 @@ def fetch_providers(providers_urls: Union[str, List[str]] = None) -> list:
         else:
             break
     else:
-        # Load local cached providers file
-        LOGGER.warning(
-            "Loading local, possibly outdated, list of providers (%r).",
-            CACHED_PROVIDERS.name,
-        )
-        with open(CACHED_PROVIDERS, "r") as handle:
-            providers = json.load(handle)
+        if CACHED_PROVIDERS.exists():
+            # Load local cached providers file
+            LOGGER.warning(
+                "Loading local, possibly outdated, list of providers (%r).",
+                CACHED_PROVIDERS.name,
+            )
+            with open(CACHED_PROVIDERS, "r") as handle:
+                providers = json.load(handle)
+        else:
+            LOGGER.error(
+                "Neither any of the provider URLs: %r returned a valid response, "
+                "and the local cached file of the latest valid response does not exist.",
+                providers_urls,
+            )
+            providers = {}
 
     update_local_providers_json(providers)
     return providers.get("data", [])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,11 +2,21 @@ from aiidalab_optimade import utils
 
 
 def test_fetch_providers_wrong_url():
-    """Test when fetch_providers is provided a wrong URL"""
+    """Test when fetch_providers is provided a wrong URL
+
+    It should now return at the very least the cached list of providers
+    """
+    import json
+
     wrong_url = "https://this.is.a.wrong.url"
 
-    providers = utils.fetch_providers(providers_url=wrong_url)
-    assert providers == []
+    providers = utils.fetch_providers(providers_urls=wrong_url)
+    if utils.CACHED_PROVIDERS.exists():
+        with open(utils.CACHED_PROVIDERS, "r") as handle:
+            providers_file = json.load(handle)
+        assert providers == providers_file.get("data", [])
+    else:
+        assert providers == []
 
 
 def test_fetch_providers_content():


### PR DESCRIPTION
Order of tries:

1. providers.optimade.org Index Meta-Database
2. GitHub Materials-Consortia/providers repo
3. Local cached file of latest successful response

Closes #107