### PR TITLE
Use periodic table widget

### DIFF
--- a/OPTIMADE Client.ipynb
+++ b/OPTIMADE Client.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 0,
    "metadata": {},
    "outputs": [
     {
@@ -72,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 0,
    "metadata": {},
    "outputs": [
     {
@@ -96,7 +96,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 0,
    "metadata": {},
    "outputs": [
     {
@@ -120,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 0,
    "metadata": {},
    "outputs": [
     {
@@ -177,13 +177,6 @@
     "\n",
     "display(filters_summary)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -10,3 +10,6 @@ jupyter nbextension enable --py --sys-prefix nglview
 # Voilà
 jupyter nbextension enable --py --sys-prefix voila
 
+# Period Table
+jupyter nbextension enable --py --sys-prefix widget_periodictable
+

--- a/optimade_client/subwidgets/__init__.py
+++ b/optimade_client/subwidgets/__init__.py
@@ -2,6 +2,7 @@
 from .filter_inputs import *
 from .multi_checkbox import *
 from .output_summary import *
+from .periodic_table import *
 from .provider_database import *
 from .results import *
 
@@ -10,6 +11,7 @@ __all__ = (
     filter_inputs.__all__  # noqa
     + multi_checkbox.__all__  # noqa
     + output_summary.__all__  # noqa
+    + periodic_table.__all__  # noqa
     + provider_database.__all__  # noqa
     + results.__all__  # noqa
 )

--- a/optimade_client/subwidgets/periodic_table.py
+++ b/optimade_client/subwidgets/periodic_table.py
@@ -1,0 +1,69 @@
+import ipywidgets as ipw
+
+from widget_periodictable import PTableWidget
+
+from optimade_client.logger import LOGGER
+
+
+__all__ = ("PeriodicTable",)
+
+
+class PeriodicTable(ipw.VBox):
+    """Wrapper-widget for PTableWidget"""
+
+    def __init__(self, **kwargs):
+        self._disabled = kwargs.get("disabled", False)
+
+        self.select_any_all = ipw.Checkbox(
+            value=False,
+            description="Structure must ex-/include ALL chosen elements",
+            indent=False,
+            width="auto",
+            disabled=kwargs.get("disabled", False),
+        )
+        self.ptable = PTableWidget(**kwargs)
+
+        super().__init__(
+            children=(self.select_any_all, self.ptable),
+            layout=kwargs.get("layout", {}),
+        )
+
+    @property
+    def value(self) -> dict:
+        """Return value for wrapped PTableWidget"""
+        LOGGER.debug(
+            "PeriodicTable: PTableWidget.selected_elements = %r",
+            self.ptable.selected_elements,
+        )
+        LOGGER.debug(
+            "PeriodicTable: Select ANY (False) or ALL (True) = %r",
+            self.select_any_all.value,
+        )
+
+        return self.select_any_all.value, self.ptable.selected_elements.copy()
+
+    @property
+    def disabled(self) -> None:
+        """Disable widget"""
+        return self._disabled
+
+    @disabled.setter
+    def disabled(self, value: bool) -> None:
+        """Disable widget"""
+        if not isinstance(value, bool):
+            raise TypeError("disabled must be a boolean")
+
+        self.select_any_all.disabled = self.ptable.disabled = value
+
+    def reset(self):
+        """Reset widget"""
+        self.select_any_all.value = False
+        self.ptable.selected_elements = {}
+
+    def freeze(self):
+        """Disable widget"""
+        self.disabled = True
+
+    def unfreeze(self):
+        """Activate widget (in its current state)"""
+        self.disabled = False

--- a/optimade_client/summary.py
+++ b/optimade_client/summary.py
@@ -89,14 +89,6 @@ class DownloadChooser(ipw.HBox):
         ),
         ("Protein Data Bank (.pdb)", {"ext": ".pdb", "adapter_format": "pdb"}),
         (
-            "Crystallographic Information File v1.0 [via ASE] (.cif)",
-            {"ext": ".cif", "adapter_format": "ase", "final_format": "cif"},
-        ),
-        (
-            "Protein Data Bank [via ASE] (.pdb)",
-            {"ext": ".pdb", "adapter_format": "ase", "final_format": "proteindatabank"},
-        ),
-        (
             "XMol XYZ File [via ASE] (.xyz)",
             {"ext": ".xyz", "adapter_format": "ase", "final_format": "xyz"},
         ),

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pandas~=1.1
 pkginfo~=1.5
 requests~=2.24
 voila~=0.2.2
+widget_periodictable~=2.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,3 @@
-black~=20.8b1
 invoke~=1.4
 pre-commit~=2.7
 pylint~=2.6


### PR DESCRIPTION
Closes #48 

Use the Periodic Table widget from OSSCAR as input of "Elements".
Using "states" it can act as input for both including and excluding.

Issues left to solve:
- [X] Update published version of widget (to PyPI) to newest develop version.
- [X] Fix basic bugs in widget (trailing `;`, etc.)
- [X] Allow changing the layout (being able to set HTML CSS width, height, etc.)