### PR TITLE
Publish through GitHub release

### DIFF
--- a/.github/static/release_tag_msg.txt
+++ b/.github/static/release_tag_msg.txt
@@ -1,0 +1,4 @@
+TAG_NAME
+
+This tag was created automatically through the GH Actions
+"Publish on PyPI" workflow.

--- a/.github/static/update_version.sh
+++ b/.github/static/update_version.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -e
+
+echo "\n### Checkout fresh branch ###"
+git checkout -b update_version
+
+echo "\n### Setting commit user ###"
+git config --local user.email "casper.andersen@epfl.ch"
+git config --local user.name "CasperWA"
+
+echo "\n### Install invoke ###"
+pip install -U invoke
+
+echo "\n### Update version ###"
+invoke update-version --version="${GITHUB_REF#refs/tags/}"
+
+echo "\n### Commit updated files ###"
+git add setup.py
+git add optimade_client/version.py
+git commit -m "Release ${GITHUB_REF#refs/tags/}"

--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -1,38 +1,52 @@
 name: Publish on PyPI
 
 on:
-  push:
-    tags:
-      - 20[2-9][0-9].?[0-9].?[0-9]*
+  release:
+    types:
+      - published
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     if: github.repository == 'CasperWA/voila-optimade-client' && startsWith(github.ref, 'refs/tags/20')
+    env:
+      PUBLISH_UPDATE_BRANCH: develop
 
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
         python-version: 3.8
 
-    - name: Install python requirements
+    - name: Update setuptools
       run: |
         python -m pip install --upgrade pip
         pip install -U setuptools
-        pip install -U invoke
 
-    - name: Checkout repository
-      uses: actions/checkout@v2
+    - name: Update version and update '${{ env.PUBLISH_UPDATE_BRANCH }}'
+      uses: CasperWA/push-protected@v1
+      with:
+        token: ${{ secrets.RELEASE_PAT }}
+        branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
+        changes: .github/static/update_version.sh
 
-    - name: Assert package version
+    - name: Update tag to latest commit (getting the newest version locally)
       run: |
-        invoke update-version --version="${GITHUB_REF#refs/tags/}"
-        if [ -n "$(git status --porcelain --untracked-files=no --ignored=no)" ]; then
-          echo "It seems updating the version to ${GITHUB_REF#refs/tags/} results in modified files in the repository."
-          git status
-          exit 1
-        fi
+        git config --local user.email "casper.andersen@epfl.ch"
+        git config --local user.name "CasperWA"
+
+        git fetch origin
+        git branch ${{ env.PUBLISH_UPDATE_BRANCH }} origin/${{ env.PUBLISH_UPDATE_BRANCH }}
+        git checkout ${{ env.PUBLISH_UPDATE_BRANCH }}
+
+        TAG_MSG=.github/static/release_tag_msg.txt
+        sed -i "s|TAG_NAME|${GITHUB_REF#refs/tags/}|g" "${TAG_MSG}"
+
+        git tag -af -F "${TAG_MSG}" ${GITHUB_REF#refs/tags/}
+        git push -f --tags
 
     - name: Build source distribution
       run: python ./setup.py sdist


### PR DESCRIPTION
Use [`CasperWA/push-protected`](https://github.com/CasperWA/push-protected) to ensure the version is updated in the code
base accordingly.