### PR TITLE
Update scipy install

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,17 +61,7 @@ First, you will need to install the package either from [PyPI](https://pypi.org/
 #### PyPI
 
 ```shell
-$ pip install -U numpy
-$ pip install --no-binary :all: scipy
 $ pip install optimade-client
-```
-
-or
-
-```shell
-$ pip install optimade-client
-$ pip uninstall -y scipy
-$ pip install --no-binary :all: scipy
 ```
 
 #### GitHub
@@ -79,11 +69,10 @@ $ pip install --no-binary :all: scipy
 ```shell
 $ git clone https://github.com/CasperWA/voila-optimade-client.git
 $ cd voila-optimade-client
-voila-optimade-client$ pip install -r requirements.txt
 voila-optimade-client$ pip install .
 ```
 
-Note, both of these methods install scipy by rebuilding the binaries based on the local numpy installation. This can take a considerable time, but will result in a more stable application, especially concerning converting structures to other data formats for download.
+If you wish to contribute to the application, you can install it in "editable" mode by using the `-e` flag: `pip install -e .`
 
 To now run the application (notebook) [`OPTIMADE Client.ipynb`](OPTIMADE%20Client.ipynb) you can simply run the command `optimade-client` in a terminal and go to the printed URL (usually <http://localhost:8866>) or pass the `--open-browser` option to let the program try to automatically open your default browser at the URL.
 

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,12 +1,1 @@
-appdirs~=1.4.4
-appmode~=0.8.0
-ase~=3.20
-click~=7.1
-ipywidgets~=7.5
-jupyterlab~=2.2
-nglview~=2.7
-numpy~=1.19
-optimade~=0.12.0
-pandas~=1.1
-requests~=2.24
-voila~=0.1.23
+../requirements.txt

--- a/optimade_client/summary.py
+++ b/optimade_client/summary.py
@@ -216,6 +216,19 @@ document.body.removeChild(link);" />
                 if isinstance(output, str):
                     output = output.encode(encoding)
                 data = base64.b64encode(output).decode()
+            except RuntimeWarning as warn:
+                if "numpy.ufunc size changed" in str(warn):
+                    # This is an issue that may occur if using pre-built binaries for numpy and scipy.
+                    # It can be resolved by uninstalling scipy and reinstalling it with `--no-binary :all:`
+                    # when using pip. This will recompile all related binaries using the currently
+                    # installed numpy version.
+                    # However, it shouldn't be critical, hence here the warning will be ignored.
+                    pass
+                else:
+                    self.download_button.value = self._download_button_format.format(
+                        disabled="disabled", encoding="", data="", filename=""
+                    )
+                    warnings.warn(OptimadeClientWarning(warn))
             except Warning as warn:
                 self.download_button.value = self._download_button_format.format(
                     disabled="disabled", encoding="", data="", filename=""

--- a/optimade_client/summary.py
+++ b/optimade_client/summary.py
@@ -238,9 +238,7 @@ document.body.removeChild(link);" />
         if desired_format["ext"] == ".cif":
             encoding = "latin-1"
 
-        filename = (
-            f"optimade_structure_{self.structure.id}{desired_format['ext']}"
-        )
+        filename = f"optimade_structure_{self.structure.id}{desired_format['ext']}"
 
         if isinstance(output, str):
             output = output.encode(encoding)

--- a/optimade_client/summary.py
+++ b/optimade_client/summary.py
@@ -194,36 +194,17 @@ document.body.removeChild(link);" />
                 output = getattr(
                     self.structure, f"as_{desired_format['adapter_format']}"
                 )
-
-                if desired_format["adapter_format"] in (
-                    "ase",
-                    "pymatgen",
-                    "aiida_structuredata",
-                ):
-                    # output is not a file, but a proxy Python class
-                    func = getattr(self, f"_get_via_{desired_format['adapter_format']}")
-                    output = func(output, desired_format=desired_format["final_format"])
-                encoding = "utf-8"
-
-                # Specifically for CIF: v1.x CIF needs to be in "latin-1" formatting
-                if desired_format["ext"] == ".cif":
-                    encoding = "latin-1"
-
-                filename = (
-                    f"optimade_structure_{self.structure.id}{desired_format['ext']}"
-                )
-
-                if isinstance(output, str):
-                    output = output.encode(encoding)
-                data = base64.b64encode(output).decode()
             except RuntimeWarning as warn:
                 if "numpy.ufunc size changed" in str(warn):
-                    # This is an issue that may occur if using pre-built binaries for numpy and scipy.
-                    # It can be resolved by uninstalling scipy and reinstalling it with `--no-binary :all:`
-                    # when using pip. This will recompile all related binaries using the currently
-                    # installed numpy version.
+                    # This is an issue that may occur if using pre-built binaries for numpy and
+                    # scipy. It can be resolved by uninstalling scipy and reinstalling it with
+                    # `--no-binary :all:` when using pip. This will recompile all related binaries
+                    # using the currently installed numpy version.
                     # However, it shouldn't be critical, hence here the warning will be ignored.
-                    pass
+                    warnings.filterwarnings("default")
+                    output = getattr(
+                        self.structure, f"as_{desired_format['adapter_format']}"
+                    )
                 else:
                     self.download_button.value = self._download_button_format.format(
                         disabled="disabled", encoding="", data="", filename=""
@@ -242,10 +223,32 @@ document.body.removeChild(link);" />
                     raise exc
                 # Else wrap the exception to make sure to log it.
                 raise exceptions.OptimadeClientError(exc)
-            else:
-                self.download_button.value = self._download_button_format.format(
-                    disabled="", encoding=encoding, data=data, filename=filename
-                )
+
+        if desired_format["adapter_format"] in (
+            "ase",
+            "pymatgen",
+            "aiida_structuredata",
+        ):
+            # output is not a file, but a proxy Python class
+            func = getattr(self, f"_get_via_{desired_format['adapter_format']}")
+            output = func(output, desired_format=desired_format["final_format"])
+        encoding = "utf-8"
+
+        # Specifically for CIF: v1.x CIF needs to be in "latin-1" formatting
+        if desired_format["ext"] == ".cif":
+            encoding = "latin-1"
+
+        filename = (
+            f"optimade_structure_{self.structure.id}{desired_format['ext']}"
+        )
+
+        if isinstance(output, str):
+            output = output.encode(encoding)
+        data = base64.b64encode(output).decode()
+
+        self.download_button.value = self._download_button_format.format(
+            disabled="", encoding=encoding, data=data, filename=filename
+        )
 
     @staticmethod
     def _get_via_pymatgen(

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,4 @@ numpy~=1.19
 optimade~=0.12.0
 pandas~=1.1
 requests~=2.24
-scipy~=1.5 --install-option="--no-binary=':all:'"
 voila~=0.1.23


### PR DESCRIPTION
Remove `scipy` dependency.

This fixes #91, in the sense that this particular warning (`numpy.ufunc size changed`) is ignored.
This is considered "fine" due to the extent of this warning having no actual influence on the end result.

The README has also been updated by removing the mention of recompiling `scipy`.

Finally, binder's `requirements.txt` has been made into a symlink pointing to the root `requirements.txt`, since this should again work with the removal of `scipy`.