### PR TITLE
Add logo to package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include requirements*.txt
 include LICENSE
 include optimade_client/cli/static/*.json
+include img/optimade-text-right-transparent-bg.png

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     version="2020.9.16.dev0",
     license="MIT License",
     author="Casper Welzel Andersen",
+    author_email="casper.andersen@epfl.ch",
     description="Voilà/Jupyter client for searching through OPTIMADE databases.",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Fixes #153.
A logo is used in the package, this has now been added to the `MANIFEST.in`.

Furthermore, `author_email` has been added to `setup()`, since it is mandatory if `author` is supplied.