### PR TITLE
Simple caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install -U pip
         pip install flake8
 
     - name: Lint with flake8
@@ -25,7 +25,7 @@ jobs:
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        flake8 . --count --statistics
 
   pre-commit:
 
@@ -46,7 +46,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install -U pip
         pip install -U setuptools
         pip install pre-commit
 
@@ -72,7 +72,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install -U pip
         pip install -U setuptools
         pip install -e .[testing]
 

--- a/optimade_client/subwidgets/__init__.py
+++ b/optimade_client/subwidgets/__init__.py
@@ -1,17 +1,17 @@
 # pylint: disable=undefined-variable
-from .filter_inputs import *
-from .multi_checkbox import *
-from .output_summary import *
-from .periodic_table import *
-from .provider_database import *
-from .results import *
+from .filter_inputs import *  # noqa: F403
+from .multi_checkbox import *  # noqa: F403
+from .output_summary import *  # noqa: F403
+from .periodic_table import *  # noqa: F403
+from .provider_database import *  # noqa: F403
+from .results import *  # noqa: F403
 
 
 __all__ = (
-    filter_inputs.__all__  # noqa
-    + multi_checkbox.__all__  # noqa
-    + output_summary.__all__  # noqa
-    + periodic_table.__all__  # noqa
-    + provider_database.__all__  # noqa
-    + results.__all__  # noqa
+    filter_inputs.__all__  # noqa: F405
+    + multi_checkbox.__all__  # noqa: F405
+    + output_summary.__all__  # noqa: F405
+    + periodic_table.__all__  # noqa: F405
+    + provider_database.__all__  # noqa: F405
+    + results.__all__  # noqa: F405
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 appdirs~=1.4.4
 appmode~=0.8.0
 ase~=3.20
+cachecontrol[filecache]~=0.12.6
 click~=7.1
 ipywidgets~=7.5
 jupyterlab~=2.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,8 @@
+[flake8]
+ignore =
+    # Line to long. Handled by black.
+    E501
+    # Line break before binary operator. This is preferred formatting for black.
+    W503
+    # Whitespace before ':'
+    E203

--- a/tasks.py
+++ b/tasks.py
@@ -13,7 +13,9 @@ TOP_DIR = Path(__file__).parent.resolve()
 def update_file(filename: str, sub_line: Tuple[str, str], strip: str = None):
     """Utility function for tasks to read, update, and write files"""
     with open(filename, "r") as handle:
-        lines = [re.sub(sub_line[0], sub_line[1], l.rstrip(strip)) for l in handle]
+        lines = [
+            re.sub(sub_line[0], sub_line[1], line.rstrip(strip)) for line in handle
+        ]
 
     with open(filename, "w") as handle:
         handle.write("\n".join(lines))


### PR DESCRIPTION
Related to #138.
While it does not implement asynchronous requests, it does implement cached responses.

Good for server-side caching:
- Make sure requests are similar to previous ones.
  All query parameters and values are either added in an OrderedDict or extracted from a complete URL, sorted and reencoded into a complete URL.

Client side caching:
- Employ [CacheControl](https://cachecontrol.readthedocs.io/en/latest/index.html) with a file cache that persists responses for 24h.

Also supplied `flake8` with some teeth in CI and updated the code accordingly.

---

Missing:
- [x] No caching on "Local server" in debug mode.