### PR TITLE
Use pkginfo package

### DIFF
--- a/optimade_client/__init__.py
+++ b/optimade_client/__init__.py
@@ -7,9 +7,9 @@ from .informational import OptimadeClientFAQ, HeaderDescription, OptimadeLog
 from .query_provider import OptimadeQueryProviderWidget
 from .query_filter import OptimadeQueryFilterWidget
 from .summary import OptimadeSummaryWidget
-from .version import __version__
 
 
+__version__ = "2020.9.16.dev2"
 __all__ = (
     "HeaderDescription",
     "OptimadeClientFAQ",

--- a/optimade_client/informational.py
+++ b/optimade_client/informational.py
@@ -5,14 +5,15 @@ from typing import Union
 from urllib.parse import urlencode
 
 import ipywidgets as ipw
+from pkginfo import Installed
 
 from optimade_client.logger import LOGGER, WIDGET_HANDLER, REPORT_HANDLER
-
 from optimade_client.utils import __optimade_version__
 
 
 IMG_DIR = Path(__file__).parent.joinpath("img")
 SOURCE_URL = "https://github.com/CasperWA/voila-optimade-client/"
+PKG_INFO = Installed("optimade_client")
 
 
 class HeaderDescription(ipw.VBox):
@@ -33,9 +34,8 @@ class HeaderDescription(ipw.VBox):
     """
 
     HEADER = f"""<p style="font-size:14px;">
-<b>Currently valid OPTIMADE API version</b>: <code>v{__optimade_version__[0]}</code>
-</p>
-<p style="font-size:14px;">
+<b>Currently valid OPTIMADE API version</b>: <code>v{__optimade_version__[0]}</code><br>
+<b>Client version</b>: <code>{PKG_INFO.version}</code><br>
 <b>Source code</b>: <a href="{SOURCE_URL}" target="_blank">GitHub</a>
 </p>
 """

--- a/optimade_client/logger.py
+++ b/optimade_client/logger.py
@@ -8,11 +8,11 @@ import warnings
 
 import appdirs
 import ipywidgets as ipw
+from pkginfo import Installed
 
-from optimade_client.version import APP_NAME, APP_AUTHOR
 
-
-LOG_DIR = Path(appdirs.user_log_dir(APP_NAME, APP_AUTHOR))
+PKG_INFO = Installed("optimade_client")
+LOG_DIR = Path(appdirs.user_log_dir(PKG_INFO.name, PKG_INFO.author))
 LOG_DIR.mkdir(parents=True, exist_ok=True)
 
 LOG_FILE = LOG_DIR / "optimade_client.log"

--- a/optimade_client/utils.py
+++ b/optimade_client/utils.py
@@ -11,6 +11,7 @@ except (ImportError, ModuleNotFoundError):
 from json import JSONDecodeError
 
 import appdirs
+from pkginfo import Installed
 from pydantic import ValidationError, AnyUrl  # pylint: disable=no-name-in-module
 import requests
 
@@ -22,7 +23,6 @@ from optimade_client.exceptions import (
     InputError,
 )
 from optimade_client.logger import LOGGER
-from optimade_client.version import APP_NAME, APP_AUTHOR
 
 
 # Supported OPTIMADE spec versions
@@ -36,7 +36,8 @@ PROVIDERS_URLS = [
     "/links/v1/providers.json",
 ]
 
-CACHE_DIR = Path(appdirs.user_cache_dir(APP_NAME, APP_AUTHOR))
+PKG_INFO = Installed("optimade_client")
+CACHE_DIR = Path(appdirs.user_cache_dir(PKG_INFO.name, PKG_INFO.author))
 CACHE_DIR.mkdir(parents=True, exist_ok=True)
 CACHED_PROVIDERS = CACHE_DIR / "cached_providers.json"
 

--- a/optimade_client/version.py
+++ b/optimade_client/version.py
@@ -1,4 +1,0 @@
-APP_NAME = "OPTIMADE-Client"
-APP_AUTHOR = "CasperWA"
-
-__version__ = "2020.9.16.dev2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,6 @@ nglview~=2.7
 numpy~=1.19
 optimade~=0.12.0
 pandas~=1.1
+pkginfo~=1.5
 requests~=2.24
 voila~=0.2.2

--- a/tasks.py
+++ b/tasks.py
@@ -36,7 +36,7 @@ def update_version(_, version=""):
         version = f"{today.year}.{today.month}.{today.day}"
 
     update_file(
-        TOP_DIR.joinpath("optimade_client/version.py"),
+        TOP_DIR.joinpath("optimade_client/__init__.py"),
         ("__version__ = .+", f'__version__ = "{version}"'),
     )
     update_file(


### PR DESCRIPTION
This removes the `version.py` file and instead retrieves distribution information for appdirs via the pkginfo package.