### PR TITLE
Add button_style arguments to widgets

### DIFF
--- a/optimade_client/informational.py
+++ b/optimade_client/informational.py
@@ -7,7 +7,7 @@ from urllib.parse import urlencode
 import ipywidgets as ipw
 
 from optimade_client.logger import LOGGER, WIDGET_HANDLER, REPORT_HANDLER
-from optimade_client.utils import __optimade_version__
+from optimade_client.utils import __optimade_version__, ButtonStyle
 
 
 IMG_DIR = Path(__file__).parent.joinpath("img")
@@ -68,10 +68,15 @@ Follow <a href="{SOURCE_URL}issues/12" target="_blank">the issue on GitHub</a> t
         ),
     }
 
-    def __init__(self, logo: str = None, **kwargs):
+    def __init__(self, logo: str = None, button_style: ButtonStyle = None, **kwargs):
         logo = logo if logo is not None else "optimade-text-right-transparent-bg.png"
         logo = self._get_file(str(IMG_DIR.joinpath(logo)))
         logo = ipw.Image(value=logo, format="png", width=375, height=137.5)
+
+        if button_style is not None and isinstance(button_style, str):
+            button_style = ButtonStyle[button_style.upper()]
+        else:
+            button_style = ButtonStyle.DEFAULT
 
         header = ipw.HTML(self.HEADER)
 
@@ -79,7 +84,7 @@ Follow <a href="{SOURCE_URL}issues/12" target="_blank">the issue on GitHub</a> t
         self._debug_log = REPORT_HANDLER.get_widget()
         self.report_bug = ipw.HTML(
             f"""
-<button type="button" class="p-Widget jupyter-widgets jupyter-button widget-button mod-info"
+<button type="button" class="p-Widget jupyter-widgets jupyter-button widget-button mod-{button_style.value}"
 title="Create a bug issue on GitHub that includes a log file" style="width:auto;"
 onclick="
 var log = document.getElementById('{self._debug_log.element_id}');
@@ -98,7 +103,7 @@ document.body.removeChild(link);">
 <form target="_blank" style="width:auto;height:auto;" action="{SOURCE_URL}issues/new">
 <input type="hidden" name="title" value="{self.SUGGESTION_TEMPLATE["title"]}" />
 <input type="hidden" name="body" value="{self.SUGGESTION_TEMPLATE["body"]}" />
-<button type="submit" class="p-Widget jupyter-widgets jupyter-button widget-button mod-info"
+<button type="submit" class="p-Widget jupyter-widgets jupyter-button widget-button mod-{button_style.value}"
 title="Create an enhancement issue on GitHub" style="width:auto;">
 <i class="fa fa-star"></i>Suggest a feature/change</button></form>"""
         )

--- a/optimade_client/query_filter.py
+++ b/optimade_client/query_filter.py
@@ -20,6 +20,7 @@ from optimade_client.subwidgets import (
     ResultsPageChooser,
 )
 from optimade_client.utils import (
+    ButtonStyle,
     perform_optimade_query,
     handle_errors,
     TIMEOUT_SECONDS,
@@ -47,8 +48,15 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
         traitlets.Instance(LinksResourceAttributes, allow_none=True),
     )
 
-    def __init__(self, result_limit: int = None, **kwargs):
+    def __init__(
+        self, result_limit: int = None, button_style: ButtonStyle = None, **kwargs
+    ):
         self.page_limit = result_limit if result_limit else 10
+        if button_style and isinstance(button_style, str):
+            button_style = ButtonStyle[button_style.upper()]
+        else:
+            button_style = ButtonStyle.PRIMARY
+
         self.offset = 0
         self.number = 1
         self._data_available = None
@@ -66,7 +74,7 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
 
         self.query_button = ipw.Button(
             description="Search",
-            button_style="primary",
+            button_style=button_style.value,
             icon="search",
             disabled=True,
             tooltip="Search - No database chosen",

--- a/optimade_client/utils.py
+++ b/optimade_client/utils.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from pathlib import Path
 import re
 from typing import Tuple, List, Union, Iterable
@@ -38,6 +39,17 @@ PROVIDERS_URLS = [
 CACHE_DIR = Path(appdirs.user_cache_dir("optimade-client", "CasperWA"))
 CACHE_DIR.mkdir(parents=True, exist_ok=True)
 CACHED_PROVIDERS = CACHE_DIR / "cached_providers.json"
+
+
+class ButtonStyle(Enum):
+    """Enumeration of button styles"""
+
+    DEFAULT = "default"
+    PRIMARY = "primary"
+    INFO = "info"
+    SUCCESS = "success"
+    WARNING = "warning"
+    DANGER = "danger"
 
 
 def perform_optimade_query(  # pylint: disable=too-many-arguments,too-many-branches,too-many-locals


### PR DESCRIPTION
This adds a `button_style` parameter to the widgets `HeaderDescription`, `OptimadeQueryFilterWidget`, and `OptimadeSummaryWidget`.
The parameter is based on an enumeration of the different styles of buttons allowed: "default", "primary", "info", "success", "warnings", "danger".

The buttons affected all default to "default", except the Search button in `OptimadeQueryFilterWidget`, which defaults to "primary".