### PR TITLE
Make urlencode properly parse query

### DIFF
--- a/optimade_client/utils.py
+++ b/optimade_client/utils.py
@@ -637,8 +637,10 @@ def update_old_links_resources(resource: dict) -> Union[LinksResource, None]:
 
 def ordered_query_url(url: str) -> str:
     """Decode URL, sort queries, re-encode URL"""
+    LOGGER.debug("Ordering URL: %s", url)
     parsed_url = urlparse(url)
     queries = parse_qs(parsed_url.query)
+    LOGGER.debug("Queries to sort and order: %s", queries)
 
     sorted_keys = sorted(queries.keys())
 
@@ -647,9 +649,11 @@ def ordered_query_url(url: str) -> str:
         # Since the values are all lists, we also sort these
         res[key] = sorted(queries[key])
 
-    res = urlencode(res)
+    res = urlencode(res, doseq=True)
     res = (
         f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path};{parsed_url.params}?{res}"
         f"#{parsed_url.fragment}"
     )
+    LOGGER.debug("Newly ordered URL: %s", res)
+    LOGGER.debug("Treated URL after unparse(parse): %s", urlunparse(urlparse(res)))
     return urlunparse(urlparse(res))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -86,3 +86,28 @@ def test_exmpl_not_in_list():
 
     assert exmpl not in list_of_database_providers
     assert mcloud in list_of_database_providers or odbx in list_of_database_providers
+
+
+def test_ordered_query_url():
+    """Check ordered_query_url().
+
+    Testing already sorted URLs, making sure they come out exactly the same as when they came in.
+    """
+    normal_url = (
+        "https://optimade.materialsproject.org/v1.0.0/structures?filter=%28+nelements%3E%3D1+AND+"
+        "nelements%3C%3D9+AND+nsites%3E%3D1+AND+nsites%3C%3D444+%29+AND+%28+NOT+structure_features"
+        "+HAS+ANY+%22assemblies%22+%29&page_limit=10&page_number=1&page_offset=30&response_format"
+        "=json"
+    )
+    multi_query_param_url = (
+        "https://optimade.materialsproject.org/v1.0.0/structures?filter=%28+nelements%3E%3D1+AND+"
+        "nelements%3C%3D9+AND+nsites%3E%3D1+AND+nsites%3C%3D444+%29+AND+%28+NOT+structure_features"
+        "+HAS+ANY+%22assemblies%22+%29&page_limit=10&page_number=1&page_offset=30&response_format"
+        "=json&response_format=xml"
+    )
+
+    ordered_url = utils.ordered_query_url(normal_url)
+    assert ordered_url == normal_url
+
+    ordered_url = utils.ordered_query_url(multi_query_param_url)
+    assert ordered_url == multi_query_param_url


### PR DESCRIPTION
Fixes #172

The issue came down to setting `doseq=True` in `urllib.parse.urlencode()`.
A test has also been added for the `ordered_query_url()` utility function.