### PR TITLE
Properly implement `button_style` parameter in button's HTML

### DIFF
--- a/optimade_client/informational.py
+++ b/optimade_client/informational.py
@@ -74,8 +74,16 @@ Follow <a href="{SOURCE_URL}issues/12" target="_blank">the issue on GitHub</a> t
         logo = self._get_file(str(IMG_DIR.joinpath(logo)))
         logo = ipw.Image(value=logo, format="png", width=375, height=137.5)
 
-        if button_style is not None and isinstance(button_style, str):
-            button_style = ButtonStyle[button_style.upper()]
+        if button_style:
+            if isinstance(button_style, str):
+                button_style = ButtonStyle[button_style.upper()]
+            elif isinstance(button_style, ButtonStyle):
+                pass
+            else:
+                raise TypeError(
+                    "button_style should be either a string or a ButtonStyle Enum. "
+                    f"You passed type {type(button_style)!r}."
+                )
         else:
             button_style = ButtonStyle.DEFAULT
 

--- a/optimade_client/informational.py
+++ b/optimade_client/informational.py
@@ -69,7 +69,9 @@ Follow <a href="{SOURCE_URL}issues/12" target="_blank">the issue on GitHub</a> t
         ),
     }
 
-    def __init__(self, logo: str = None, button_style: ButtonStyle = None, **kwargs):
+    def __init__(
+        self, logo: str = None, button_style: Union[ButtonStyle, str] = None, **kwargs
+    ):
         logo = logo if logo is not None else "optimade-text-right-transparent-bg.png"
         logo = self._get_file(str(IMG_DIR.joinpath(logo)))
         logo = ipw.Image(value=logo, format="png", width=375, height=137.5)

--- a/optimade_client/query_filter.py
+++ b/optimade_client/query_filter.py
@@ -51,7 +51,10 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
     )
 
     def __init__(
-        self, result_limit: int = None, button_style: ButtonStyle = None, **kwargs
+        self,
+        result_limit: int = None,
+        button_style: Union[ButtonStyle, str] = None,
+        **kwargs,
     ):
         self.page_limit = result_limit if result_limit else 10
         if button_style:

--- a/optimade_client/query_filter.py
+++ b/optimade_client/query_filter.py
@@ -54,8 +54,16 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
         self, result_limit: int = None, button_style: ButtonStyle = None, **kwargs
     ):
         self.page_limit = result_limit if result_limit else 10
-        if button_style and isinstance(button_style, str):
-            button_style = ButtonStyle[button_style.upper()]
+        if button_style:
+            if isinstance(button_style, str):
+                button_style = ButtonStyle[button_style.upper()]
+            elif isinstance(button_style, ButtonStyle):
+                pass
+            else:
+                raise TypeError(
+                    "button_style should be either a string or a ButtonStyle Enum. "
+                    f"You passed type {type(button_style)!r}."
+                )
         else:
             button_style = ButtonStyle.PRIMARY
 

--- a/optimade_client/summary.py
+++ b/optimade_client/summary.py
@@ -39,7 +39,10 @@ class OptimadeSummaryWidget(ipw.Box):
     entity = traitlets.Instance(Structure, allow_none=True)
 
     def __init__(
-        self, direction: str = None, button_style: ButtonStyle = None, **kwargs
+        self,
+        direction: str = None,
+        button_style: Union[ButtonStyle, str] = None,
+        **kwargs,
     ):
         if direction and direction == "horizontal":
             direction = "row"
@@ -180,7 +183,7 @@ link.click();
 document.body.removeChild(link);" />
 """
 
-    def __init__(self, button_style: ButtonStyle = None, **kwargs):
+    def __init__(self, button_style: Union[ButtonStyle, str] = None, **kwargs):
         if button_style:
             if isinstance(button_style, str):
                 self._button_style = ButtonStyle[button_style.upper()]

--- a/optimade_client/utils.py
+++ b/optimade_client/utils.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from enum import Enum
+from enum import Enum, EnumMeta
 from pathlib import Path
 import re
 from typing import Tuple, List, Union, Iterable
@@ -55,7 +55,23 @@ SESSION.mount("http://localhost", SESSION_ADAPTER_DEBUG)
 SESSION.mount("http://127.0.0.1", SESSION_ADAPTER_DEBUG)
 
 
-class ButtonStyle(Enum):
+class DefaultingEnum(EnumMeta):
+    """Override __getitem__()"""
+
+    def __getitem__(cls, name):
+        """Log warning and default to "DEFAULT" if name is not valid"""
+        if name not in cls._member_map_:
+            LOGGER.warning(
+                "%r is not a valid button style. Setting button style to 'DEFAULT'. "
+                "Valid button styles: %s",
+                name,
+                list(cls._member_map_.keys()),
+            )
+            name = "DEFAULT"
+        return cls._member_map_[name]
+
+
+class ButtonStyle(Enum, metaclass=DefaultingEnum):
     """Enumeration of button styles"""
 
     DEFAULT = "default"


### PR DESCRIPTION
Fixes #173

The HTML string defining the download button was updated with the `button_style` variable, but it was not always set, leading to silent errors.

The `ButtonStyle` `Enum` has been given a fallback to ´"DEFAULT"` as well (when using the `ButtonStyle[name]` style).

Initialization properly handles the case where the passed `button_style` parameter is of type `ButtonStyle`.