### PR TITLE
Fix page link handling

### DIFF
--- a/optimade_client/subwidgets/provider_database.py
+++ b/optimade_client/subwidgets/provider_database.py
@@ -331,9 +331,19 @@ class ProviderImplementationChooser(  # pylint: disable=too-many-instance-attrib
             # This may be called if a provider is suddenly removed (bad provider)
             return
 
+        if not self.__perform_query:
+            self.__perform_query = True
+            LOGGER.debug(
+                "Will not perform query with pageing: name=%s value=%s",
+                change["name"],
+                change["new"],
+            )
+            return
+
         pageing: Union[int, str] = change["new"]
         LOGGER.debug(
-            "Detected change in page_chooser's .page_offset, .page_number, or .page_link: %r",
+            "Detected change in page_chooser: name=%s value=%s",
+            change["name"],
             pageing,
         )
         if change["name"] == "page_offset":
@@ -362,11 +372,6 @@ class ProviderImplementationChooser(  # pylint: disable=too-many-instance-attrib
             with self.hold_trait_notifications():
                 self.__perform_query = False
                 self.page_chooser.update_offset()
-
-        if not self.__perform_query:
-            self.__perform_query = True
-            LOGGER.debug("Will not perform query with pageing: %r", pageing)
-            return
 
         try:
             # Freeze and disable both dropdown widgets

--- a/optimade_client/subwidgets/results.py
+++ b/optimade_client/subwidgets/results.py
@@ -162,8 +162,8 @@ class ResultsPageChooser(ipw.HBox):  # pylint: disable=too-many-instance-attribu
         """Set total number of entities"""
         try:
             value = int(value)
-        except (TypeError, ValueError):
-            raise InputError("data_returned must be an integer")
+        except (TypeError, ValueError) as exc:
+            raise InputError("data_returned must be an integer") from exc
         else:
             self._data_returned = value
 
@@ -177,8 +177,8 @@ class ResultsPageChooser(ipw.HBox):  # pylint: disable=too-many-instance-attribu
         """Set total number of entities available"""
         try:
             value = int(value)
-        except (TypeError, ValueError):
-            raise InputError("data_available must be an integer")
+        except (TypeError, ValueError) as exc:
+            raise InputError("data_available must be an integer") from exc
         else:
             self._data_available = value
 


### PR DESCRIPTION
Fixes #26 

While the #26 issue may already be fixed by previous commits, this fix will make sure that `offset` is always updated, but not acted on if a `page_link` is used to move to another page. Hence, this will officially close the issue.

The fix is to move the return block up to be the first thing that happens to avoid any cascading updates.