### PR TITLE
Don't query default nsites and nelements values

### DIFF
--- a/optimade_client/query_filter.py
+++ b/optimade_client/query_filter.py
@@ -530,6 +530,10 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
             if not data_returned:
                 self.error_or_status_messages.value = "No structures found!"
 
+        except QueryError:
+            self.structure_drop.reset()
+            self.structure_page_chooser.reset()
+
         except Exception as exc:
             self.structure_drop.reset()
             self.structure_page_chooser.reset()

--- a/optimade_client/subwidgets/intrangeslider.py
+++ b/optimade_client/subwidgets/intrangeslider.py
@@ -1,0 +1,13 @@
+from typing import Tuple, Union
+
+from ipywidgets import IntRangeSlider
+
+
+class CustomIntRangeSlider(IntRangeSlider):
+    """An IntRangeSlider that will not return values if equal to min/max"""
+
+    def get_value(self) -> Tuple[Union[int, None], Union[int, None]]:
+        """Retrieve value, making them `None` if they're equal to the extremas."""
+        min_ = None if self.min == self.value[0] else self.value[0]
+        max_ = None if self.max == self.value[1] else self.value[1]
+        return min_, max_


### PR DESCRIPTION
This work is inspired by issue #125, in the sense that COD was failing to handle `nsites`, and this is added by default even if the user has not changed it. There is no need to add a query for a non-filter. Hence, this PR will make sure to _not_ add `nsites` and `nelements` to the query filter if they are equal to their initial values.

A custom `IntRangeSlider` widget is implemented to handle returning a `None` value.
The custom `IntRangeSlider` widget simply implements a `get_value()` function that is used instead of getting the `value` attribute, which. It will return `(None, None)` if the values are equal to the `min` and `max` attributes, respectively. If only one value is altered the other will be `None`.