### PR TITLE
Add codecov (code coverage) and don't run CI for all pushes

### DIFF
--- a/.ci/codecov_validator.sh
+++ b/.ci/codecov_validator.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+if [ -n "${CI}" ]; then
+    echo "Not checking codecov configuration file when CI is true."
+    exit 0
+fi
+
+CODECOV_FILE=.codecov.yml
+
+curl -s --data-binary @${CODECOV_FILE} https://codecov.io/validate | grep Valid! || ( curl -s --data-binary @${CODECOV_FILE} https://codecov.io/validate ; exit 1)

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,16 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+
+  status:
+    project:
+      default:
+        threshold: 1
+    patch:
+      default:
+        threshold: 1
+    changes: off

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,4 +77,12 @@ jobs:
         pip install -e .[testing]
 
     - name: PyTest
-      run: pytest --cov=./optimade_client/
+      run: pytest -vvv --cov=optimade_client --cov-report=xml tests/
+
+    - name: Upload coverage to Codecov
+      if: matrix.python-version == 3.8 && github.repository == 'CasperWA/voila-optimade-client'
+      uses: codecov/codecov-action@v1
+      with:
+        name: optimade-client
+        file: ./coverage.xml
+        flags: optimade-client

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+      - stable
+      - 'push-action/**'
 
 jobs:
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,15 @@ repos:
   hooks:
   - id: black
     name: Blacken
+
+- repo: local
+  hooks:
+  - id: codecov-validator
+    name: Validate .codecov.yml
+    description: Validate .codecov.yml using codecov's online validation tool.
+    entry: ./.ci/codecov_validator.sh
+    files: >
+      (?x)^(
+        .codecov.yml
+      )$
+    language: system


### PR DESCRIPTION
Upload code coverage report to codecov from a PyTest run for Python 3.8.

Run CI workflow for all PRs, but only for pushes to `stable`, `develop`, and `push-action/**` branches.