### PR TITLE
Update pre-commit with flake8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,14 @@ jobs:
         pip install -U setuptools
         pip install pre-commit
 
+    - name: Set PY env var
+      run: echo "::set-env name=PY::$(python -VV | sha256sum | cut -d' ' -f1)"
+
+    - uses: actions/cache@v2
+      with:
+        path: ~/.cache/pre-commit
+        key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
+
     - name: Test with pre-commit
       run: pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,30 +9,6 @@ on:
       - 'push-action/**'
 
 jobs:
-
-  lint:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install dependencies
-      run: |
-        python -m pip install -U pip
-        pip install flake8
-
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --statistics
-
   pre-commit:
 
     runs-on: ubuntu-latest
@@ -60,7 +36,6 @@ jobs:
       run: pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )
 
   pytest:
-
     runs-on: ubuntu-latest
 
     strategy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,9 @@ repos:
         .codecov.yml
       )$
     language: system
+
+- repo: https://gitlab.com/pycqa/flake8
+  rev: '3.8.4'
+  hooks:
+  - id: flake8
+    args: [--count, --show-source, --statistics]


### PR DESCRIPTION
Add flake8 to pre-commit and removing the `lint` job from the CI workflow, since it is now included in the `pre-commit` job.

Use caching for `pre-commit` in CI.