### PR TITLE
Add ability to change grid widths of provider sub-widgets

### DIFF
--- a/optimade_client/query_provider.py
+++ b/optimade_client/query_provider.py
@@ -36,6 +36,7 @@ class OptimadeQueryProviderWidget(ipw.GridspecLayout):
         embedded: bool = False,
         database_limit: int = None,
         width_ratio: Union[Tuple[int, int], List[int]] = None,
+        width_space: int = None,
         **kwargs,
     ):
         database_limit = database_limit if database_limit and database_limit > 0 else 10
@@ -63,11 +64,13 @@ class OptimadeQueryProviderWidget(ipw.GridspecLayout):
             else:
                 width_ratio = (10, 21)
 
+            width_space = width_space if width_space is not None else 1
+
             super().__init__(
                 n_rows=1, n_columns=sum(width_ratio), layout=layout, **kwargs
             )
             self[:, : width_ratio[0]] = self.chooser
-            self[:, width_ratio[0] + 1 :] = self.summary
+            self[:, width_ratio[0] + width_space :] = self.summary
 
             ipw.dlink((self.chooser, "provider"), (self.summary, "provider"))
             ipw.dlink(

--- a/optimade_client/query_provider.py
+++ b/optimade_client/query_provider.py
@@ -1,5 +1,8 @@
+import warnings
+
 import ipywidgets as ipw
 import traitlets
+from typing import Union, Tuple, List
 
 from optimade.models import LinksResourceAttributes
 
@@ -7,6 +10,7 @@ from optimade_client.subwidgets import (
     ProviderImplementationChooser,
     ProviderImplementationSummary,
 )
+from optimade_client.warnings import OptimadeClientWarning
 
 
 DEFAULT_FILTER_VALUE = (
@@ -27,7 +31,13 @@ class OptimadeQueryProviderWidget(ipw.GridspecLayout):
         default_value=("", None),
     )
 
-    def __init__(self, embedded: bool = False, database_limit: int = None, **kwargs):
+    def __init__(
+        self,
+        embedded: bool = False,
+        database_limit: int = None,
+        width_ratio: Union[Tuple[int, int], List[int]] = None,
+        **kwargs,
+    ):
         database_limit = database_limit if database_limit and database_limit > 0 else 10
 
         layout = ipw.Layout(width="100%", height="auto")
@@ -42,9 +52,22 @@ class OptimadeQueryProviderWidget(ipw.GridspecLayout):
             super().__init__(n_rows=1, n_columns=1, layout=layout, **kwargs)
             self[:, :] = self.chooser
         else:
-            super().__init__(n_rows=1, n_columns=31, layout=layout, **kwargs)
-            self[:, :10] = self.chooser
-            self[:, 11:] = self.summary
+            if width_ratio is not None and isinstance(width_ratio, (tuple, list)):
+                if len(width_ratio) != 2 or sum(width_ratio) <= 0:
+                    width_ratio = (10, 21)
+                    warnings.warn(
+                        "width_ratio is not a list or tuple of length 2. "
+                        f"Will use defaults {width_ratio}.",
+                        OptimadeClientWarning,
+                    )
+            else:
+                width_ratio = (10, 21)
+
+            super().__init__(
+                n_rows=1, n_columns=sum(width_ratio), layout=layout, **kwargs
+            )
+            self[:, : width_ratio[0]] = self.chooser
+            self[:, width_ratio[0] + 1 :] = self.summary
 
             ipw.dlink((self.chooser, "provider"), (self.summary, "provider"))
             ipw.dlink(


### PR DESCRIPTION
Add `width_ratio` and `width_space` parameters to `OptimadeQueryProviderWidget`.
These parameters allows the user to specify the number of grid columns used to layout the dropdown and informational sub-widgets.
`width_space` indicates how many columns should be spaced in between the two sub-widgets.

The default is `width_ratio=(10, 21)` and `width_space=1`, meaning the total number of columns are 31 (sum of `width_ratio`) and the dropdown sub-widget spans 10 columns, while the informational sub-widget spans 20 columns (21 - the value of `width_space`, which is 1).