### PR TITLE
Reactivate publishing to PyPI

### DIFF
--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -37,18 +37,18 @@ jobs:
         force: true
         tags: true
 
-    # - name: Build source distribution
-    #   run: python ./setup.py sdist
+    - name: Build source distribution
+      run: python ./setup.py sdist
 
-    # - name: Publish package to TestPyPI
-    #   uses: pypa/gh-action-pypi-publish@master
-    #   with:
-    #     user: __token__
-    #     password: ${{ secrets.test_pypi_password }}
-    #     repository_url: https://test.pypi.org/legacy/
+    - name: Publish package to TestPyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.test_pypi_password }}
+        repository_url: https://test.pypi.org/legacy/
 
-    # - name: Publish package to PyPI
-    #   uses: pypa/gh-action-pypi-publish@master
-    #   with:
-    #     user: __token__
-    #     password: ${{ secrets.pypi_password }}
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}

--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'CasperWA/voila-optimade-client' && startsWith(github.ref, 'refs/tags/20')
     env:
-      PUBLISH_UPDATE_BRANCH: develop_test
+      PUBLISH_UPDATE_BRANCH: develop
 
     steps:
     - name: Checkout repository
@@ -30,7 +30,7 @@ jobs:
       run: .github/static/update_version.sh
 
     - name: Push updates to '${{ env.PUBLISH_UPDATE_BRANCH }}'
-      uses: CasperWA/push-protected@master
+      uses: CasperWA/push-protected@v2
       with:
         token: ${{ secrets.RELEASE_PAT }}
         branch: ${{ env.PUBLISH_UPDATE_BRANCH }}


### PR DESCRIPTION
Uncomment steps that actually publish the package on PyPI after making sure that the updated workflow functions as intended, i.e., #194 MUST first be merged and the workflow tested.

`CasperWA/push-protected` MUST first be updated to v2.0.1!
Edit: It is now updated to v2.1.0 👍 