### PR TITLE
Make Periodic Table widget toggleable

### DIFF
--- a/optimade_client/query_filter.py
+++ b/optimade_client/query_filter.py
@@ -48,6 +48,7 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
         self,
         result_limit: int = None,
         button_style: Union[ButtonStyle, str] = None,
+        embedded: bool = False,
         **kwargs,
     ):
         self.page_limit = result_limit if result_limit else 10
@@ -75,7 +76,7 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
         self.filter_header = ipw.HTML(
             '<h4 style="margin:0px;padding:0px;">Apply filters</h4>'
         )
-        self.filters = FilterTabs()
+        self.filters = FilterTabs(show_large_filters=not embedded)
         self.filters.freeze()
         self.filters.on_submit(self.retrieve_data)
 

--- a/optimade_client/query_filter.py
+++ b/optimade_client/query_filter.py
@@ -30,12 +30,6 @@ from optimade_client.utils import (
 )
 
 
-DEFAULT_FILTER_VALUE = (
-    'chemical_formula_descriptive CONTAINS "Al" OR (chemical_formula_anonymous = "AB" AND '
-    'elements HAS ALL "Si","Al","O")'
-)
-
-
 class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
     ipw.VBox
 ):

--- a/optimade_client/summary.py
+++ b/optimade_client/summary.py
@@ -287,6 +287,7 @@ document.body.removeChild(link);" />
             )
             return
 
+        output = None
         with warnings.catch_warnings():
             warnings.filterwarnings("error")
 


### PR DESCRIPTION
Closes #201.

See on [binder](https://mybinder.org/v2/gh/CasperWA/voila-optimade-client/close_201_toggle-periodic-table?urlpath=%2Fvoila%2Frender%2FOPTIMADE-Client.ipynb).

Wrap the checkbox and periodic table widget in a `VBox` container and add a button to change toggle the `visibility` layout parameter between `visible` and `hidden`.

A suggestion from my part would be to minimize the button and/or move it to the left side, but it might also be all right as is?