### PR TITLE
Remove appmode from binder postBuild

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,9 +1,5 @@
 set -ex
 
-# APP mode
-jupyter nbextension enable --py --sys-prefix appmode
-jupyter serverextension enable --py --sys-prefix appmode
-
 # NGLViewer
 jupyter nbextension enable --py --sys-prefix nglview
 


### PR DESCRIPTION
Fixes #204 

Show on [binder](https://mybinder.org/v2/gh/CasperWA/voila-optimade-client/fix_binder?urlpath=%2Fvoila%2Frender%2FOPTIMADE-Client.ipynb).