### PR TITLE
Use new check-sdist-action for build-package CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,11 +84,10 @@ jobs:
 
   build-package:
     runs-on: ubuntu-latest
-    name: Check build and installation of PyPI source distribution
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
 
-    - name: Check build and installation
+    - name: Check build and installation of PyPI source distribution
       uses: CasperWA/check-sdist-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,32 +84,11 @@ jobs:
 
   build-package:
     runs-on: ubuntu-latest
+    name: Check build and installation of PyPI source distribution
 
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+    - name: Checkout repository
+      uses: actions/checkout@v2
 
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.7
-
-    - name: Install initial dependencies
-      run: |
-        python -m pip install -U pip
-        pip install -U setuptools
-
-    - name: Build source distribution
-      run: python setup.py sdist
-
-    - name: Try to install source distribution
-      run: |
-        # Get latest git tag (for version)
-        # Move to root directory to ensure we're not in a place where checked out files
-        # may be sourced
-        ORIGINAL_PWD=$(pwd)
-        VERSION=$( git tag -l 20* --sort="version:refname" | tail -1 )
-        cd /
-        if [ "$(pwd)" = "${ORIGINAL_PWD}" ]; then echo "In original pwd: $(pwd)" && exit 1; fi
-        pip install ${ORIGINAL_PWD}/dist/optimade-client-${VERSION}.tar.gz
+    - name: Check build and installation
+      uses: CasperWA/check-sdist-action@v1


### PR DESCRIPTION
Based on the original `build-package` CI job I have created the GH Action [`check-sdist-action`](https://github.com/marketplace/actions/check-python-source-distribution).

This PR updates the `build-package` job to use this action.