### PR TITLE
Update available list of providers

### DIFF
--- a/optimade_client/query_filter.py
+++ b/optimade_client/query_filter.py
@@ -425,8 +425,8 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
         optimade_filter = self.filters.collect_value()
         optimade_filter = (
             "( {} ) AND ( {} )".format(optimade_filter, add_to_filter)
-            if optimade_filter
-            else add_to_filter
+            if optimade_filter and add_to_filter
+            else optimade_filter or add_to_filter or None
         )
         LOGGER.debug("Querying with filter: %s", optimade_filter)
 

--- a/optimade_client/subwidgets/provider_database.py
+++ b/optimade_client/subwidgets/provider_database.py
@@ -11,6 +11,8 @@ import ipywidgets as ipw
 import requests
 import traitlets
 
+from ipywidgets_extended.dropdown import DropdownExtended
+
 from optimade.models import LinksResource, LinksResourceAttributes
 from optimade.models.links import LinkType
 
@@ -62,7 +64,7 @@ class ProviderImplementationChooser(  # pylint: disable=too-many-instance-attrib
         dropdown_layout = ipw.Layout(width="auto")
 
         providers = []
-        providers = get_list_of_valid_providers()
+        providers, invalid_providers = get_list_of_valid_providers()
         providers.insert(0, (self.HINT["provider"], None))
         if self.debug:
             from optimade_client.utils import VERSION_PARTS
@@ -78,7 +80,11 @@ class ProviderImplementationChooser(  # pylint: disable=too-many-instance-attrib
             )
             providers.insert(1, ("Local server", local_provider))
 
-        self.providers = ipw.Dropdown(options=providers, layout=dropdown_layout)
+        self.providers = DropdownExtended(
+            options=providers,
+            disabled_options=invalid_providers,
+            layout=dropdown_layout,
+        )
         self.child_dbs = ipw.Dropdown(
             options=self.INITIAL_CHILD_DBS, layout=dropdown_layout, disabled=True
         )

--- a/optimade_client/utils.py
+++ b/optimade_client/utils.py
@@ -391,6 +391,13 @@ def get_list_of_valid_providers() -> Tuple[
 
         attributes = provider.attributes
 
+        # NOTE: Temporarily disable providers NOT properly satisfying the OPTIMADE specification
+        temp_disable_providers = ["cod", "tcod", "nmd"]
+        if provider.id in temp_disable_providers:
+            LOGGER.debug("Temporarily disabling provider: %s", str(provider))
+            invalid_providers.append((attributes.name, attributes))
+            continue
+
         # Skip if not an 'external' link_type database
         if attributes.link_type != LinkType.EXTERNAL:
             LOGGER.debug(

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ appdirs~=1.4.4
 ase~=3.20
 cachecontrol[filecache]~=0.12.6
 ipywidgets~=7.5
+ipywidgets-extended~=1.0
 nglview~=2.7
 optimade~=0.12.3
 pandas~=1.1

--- a/requirements/requirements_base.txt
+++ b/requirements/requirements_base.txt
@@ -1,6 +1,7 @@
 appdirs~=1.4.4
 cachecontrol[filecache]~=0.12.6
 ipywidgets~=7.5
+ipywidgets-extended~=1.0
 nglview~=2.7
 optimade~=0.12.3
 pandas~=1.1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -85,10 +85,11 @@ def test_exmpl_not_in_list():
         ),
     )
 
-    list_of_database_providers = get_list_of_valid_providers()
+    list_of_database_providers, disabled_providers = get_list_of_valid_providers()
 
     assert exmpl not in list_of_database_providers
-    assert mcloud in list_of_database_providers or odbx in list_of_database_providers
+    assert mcloud in list_of_database_providers and odbx in list_of_database_providers
+    assert mcloud[0] not in disabled_providers or odbx[0] not in disabled_providers
 
 
 def test_ordered_query_url():


### PR DESCRIPTION
Closes #219.

Temporarily disable COD, TCOD, and NOMAD from the list of providers, due to severe inconsistencies in their implementation versus proclaimed specification version.
These will be re-added once they are fully OPTIMADE compliant (to the extent this client is affected).

Show all providers in the OPTIMADE consortium-curated list of providers, but disable the providers that either don't have a public implementation yet, or (as mentioned above) for one reason or another are not fullt OPTIMADE compliant.
For this, I will use [`ipywidgets-extended`](https://github.com/CasperWA/ipywidgets-extended). Specifically, the `DropdownExtended` widget, which allows for disabling individual options in the dropdown widget.