### PR TITLE
Don't use the deprecated set-env in GH Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         pip install pre-commit
 
     - name: Set PY env var
-      run: echo "::set-env name=PY::$(python -VV | sha256sum | cut -d' ' -f1)"
+      run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
 
     - uses: actions/cache@v2
       with:


### PR DESCRIPTION
Fixes #221 