### PR TITLE
Add sorting

### DIFF
--- a/optimade_client/query_filter.py
+++ b/optimade_client/query_filter.py
@@ -96,6 +96,8 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
         )
 
         self.sort_selector = SortSelector(disabled=True)
+        self.sorting = self.sort_selector.value
+        self.sort_selector.observe(self._sort, names="value")
 
         self.structure_drop = StructureDropdown(disabled=True)
         self.structure_drop.observe(self._on_structure_select, names="value")
@@ -228,6 +230,16 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
             self.query_button.icon = "search"
             self.query_button.tooltip = "Search"
             self.unfreeze()
+
+    def _sort(self, change: dict) -> None:
+        """"Perform new query with new sorting"""
+        sort = change["new"]
+        if not sort:
+            raise ValueError(
+                f"The sort parameter could not be determined (sort={sort!r})."
+            )
+        self.sorting = sort
+        self.retrieve_data({})
 
     def freeze(self):
         """Disable widget"""
@@ -449,6 +461,7 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
             "page_limit": self.page_limit,
             "page_offset": self.offset,
             "page_number": self.number,
+            "sort": self.sorting,
         }
         LOGGER.debug(
             "Parameters (excluding filter) sent to query util func: %s",

--- a/optimade_client/query_filter.py
+++ b/optimade_client/query_filter.py
@@ -17,6 +17,7 @@ from optimade_client.logger import LOGGER
 from optimade_client.subwidgets import (
     FilterTabs,
     ResultsPageChooser,
+    SortSelector,
     StructureDropdown,
 )
 from optimade_client.utils import (
@@ -25,6 +26,7 @@ from optimade_client.utils import (
     handle_errors,
     ordered_query_url,
     perform_optimade_query,
+    get_sortable_fields,
     SESSION,
     TIMEOUT_SECONDS,
 )
@@ -92,6 +94,9 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
         self.structures_header = ipw.HTML(
             '<h4 style="margin-bottom:0px;padding:0px;">Results</h4>'
         )
+
+        self.sort_selector = SortSelector(disabled=True)
+
         self.structure_drop = StructureDropdown(disabled=True)
         self.structure_drop.observe(self._on_structure_select, names="value")
         self.error_or_status_messages = ipw.HTML("")
@@ -107,6 +112,7 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
                 self.filters,
                 self.query_button,
                 self.structures_header,
+                self.sort_selector,
                 self.structure_drop,
                 self.error_or_status_messages,
                 self.structure_page_chooser,
@@ -148,6 +154,9 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
                 self.query_button.description = "Search"
                 self.query_button.icon = "search"
                 self.query_button.tooltip = "Search"
+                self.sort_selector.valid_fields = sorted(
+                    get_sortable_fields(self.database[1].base_url)
+                )
                 self.unfreeze()
 
     def _on_structure_select(self, change):
@@ -226,6 +235,7 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
         self.filters.freeze()
         self.structure_drop.freeze()
         self.structure_page_chooser.freeze()
+        self.sort_selector.freeze()
 
     def unfreeze(self):
         """Activate widget (in its current state)"""
@@ -233,6 +243,7 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
         self.filters.unfreeze()
         self.structure_drop.unfreeze()
         self.structure_page_chooser.unfreeze()
+        self.sort_selector.unfreeze()
 
     def reset(self):
         """Reset widget"""
@@ -244,6 +255,7 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
             self.filters.reset()
             self.structure_drop.reset()
             self.structure_page_chooser.reset()
+            self.sort_selector.reset()
 
     def _uses_new_structure_features(self) -> bool:
         """Check whether self.database_version is >= v1.0.0-rc.2"""

--- a/optimade_client/subwidgets/__init__.py
+++ b/optimade_client/subwidgets/__init__.py
@@ -5,6 +5,7 @@ from .output_summary import *  # noqa: F403
 from .periodic_table import *  # noqa: F403
 from .provider_database import *  # noqa: F403
 from .results import *  # noqa: F403
+from .sort_selector import *  # noqa: F403
 
 
 __all__ = (
@@ -14,4 +15,5 @@ __all__ = (
     + periodic_table.__all__  # noqa: F405
     + provider_database.__all__  # noqa: F405
     + results.__all__  # noqa: F405
+    + sort_selector.__all__  # noqa: F405
 )

--- a/optimade_client/subwidgets/sort_selector.py
+++ b/optimade_client/subwidgets/sort_selector.py
@@ -1,4 +1,4 @@
-# pylint: disable=no-self-use
+# pylint: disable=no-self-use,too-many-instance-attributes
 from enum import Enum
 from typing import List, Union
 
@@ -30,6 +30,8 @@ class SortSelector(ipw.HBox):
     valid_fields = traitlets.List(
         traitlets.Unicode(), default_value=[field.default_value]
     )
+
+    value = traitlets.Unicode(f"{order.default_value.value}{field.default_value}")
 
     def __init__(
         self,
@@ -113,6 +115,10 @@ class SortSelector(ipw.HBox):
         """Activate widget (in its current state)"""
         self.disabled = False
 
+    def _update_latest_sorting(self) -> None:
+        """Update `latest_sorting` with current values for `field` and `order`."""
+        self.latest_sorting = {"field": self.field, "order": self.order}
+
     def _toggle_sort_availability(self) -> None:
         """Enable/Disable "Sort" button according to user choices."""
         for key, value in self.latest_sorting.items():
@@ -166,5 +172,11 @@ class SortSelector(ipw.HBox):
         self.order_select.icon = self._get_order_icon()
         self._toggle_sort_availability()
 
-    def _sort_clicked(self, button: dict) -> None:
-        """The Sort button has been clicked."""
+    def _sort_clicked(self, _: dict) -> None:
+        """The Sort button has been clicked.
+
+        Set value to current sorting settings.
+        Any usage of this widget should "observe" the `value` attribute to toggle sorting.
+        """
+        self._update_latest_sorting()
+        self.value = f"{self.order.value}{self.field}"

--- a/optimade_client/subwidgets/sort_selector.py
+++ b/optimade_client/subwidgets/sort_selector.py
@@ -1,0 +1,170 @@
+# pylint: disable=no-self-use
+from enum import Enum
+from typing import List, Union
+
+import ipywidgets as ipw
+from traitlets import traitlets
+
+
+__all__ = ("SortSelector",)
+
+
+class Order(Enum):
+    """Sort order"""
+
+    ascending = ""
+    descending = "-"
+
+
+class SortSelector(ipw.HBox):
+    """Select what to sort results by, the order, and a button to sort.
+
+    The "Sort" button will only be enabled if the the sorting field or order is changed.
+    """
+
+    field = traitlets.Unicode(default_value="id", allow_none=False)
+    order = traitlets.UseEnum(Order, default_value=Order.ascending)
+    latest_sorting = traitlets.Dict(
+        default_value={"field": field.default_value, "order": order.default_value}
+    )
+    valid_fields = traitlets.List(
+        traitlets.Unicode(), default_value=[field.default_value]
+    )
+
+    def __init__(
+        self,
+        valid_fields: List[str] = None,
+        field: str = None,
+        order: Union[str, Order] = None,
+        disabled: bool = False,
+        **kwargs,
+    ) -> None:
+        self._disabled = disabled
+
+        if valid_fields is not None:
+            self.valid_fields = valid_fields
+
+        if field is not None:
+            self.field = field
+
+        try:
+            self.order = order
+        except traitlets.TraitError:
+            # Use default
+            pass
+
+        self.order_select = ipw.ToggleButton(
+            value=self.order == Order.descending,
+            description=self.order.name.capitalize(),
+            disabled=disabled,
+            button_style="",
+            tooltip=self.order.name.capitalize(),
+            icon=self._get_order_icon(),
+            layout={"width": "101px"},
+        )
+        self.order_select.observe(self._change_order, names="value")
+
+        self.fields_drop = ipw.Dropdown(
+            options=self.valid_fields, disabled=disabled, layout={"width": "auto"}
+        )
+        self.fields_drop.observe(self._validate_field, names="value")
+
+        self.sort_button = ipw.Button(
+            description="Sort",
+            disabled=True,
+            button_style="primary",
+            tooltip="Sort the results",
+            icon="random",
+            layout={"width": "auto"},
+        )
+        self.sort_button.on_click(self._sort_clicked)
+
+        super().__init__(
+            children=(self.order_select, self.fields_drop, self.sort_button), **kwargs
+        )
+
+    @property
+    def disabled(self) -> None:
+        """Disable widget"""
+        return self._disabled
+
+    @disabled.setter
+    def disabled(self, value: bool) -> None:
+        """Disable widget"""
+        if not isinstance(value, bool):
+            raise TypeError("disabled must be a boolean")
+
+        self.order_select.disabled = self.fields_drop.disabled = value
+
+        if value:
+            self.sort_button.disabled = True
+
+    def reset(self):
+        """Reset widget"""
+        self.order_select.value = False
+        self.fields_drop.options = ["id"]
+        self.sort_button.disabled = True
+
+    def freeze(self):
+        """Disable widget"""
+        self.disabled = True
+
+    def unfreeze(self):
+        """Activate widget (in its current state)"""
+        self.disabled = False
+
+    def _toggle_sort_availability(self) -> None:
+        """Enable/Disable "Sort" button according to user choices."""
+        for key, value in self.latest_sorting.items():
+            if getattr(self, key) != value:
+                self.sort_button.disabled = False
+                break
+        else:
+            self.sort_button.disabled = True
+
+    @traitlets.observe("valid_fields")
+    def _update_drop_options(self, change: dict) -> None:
+        """Update list of sort fields dropdown."""
+        fields = change["new"]
+        if fields is None:
+            self.fields_drop.options = ["id"]
+            return
+        value = self.fields_drop.value
+        self.fields_drop.options = fields
+        self.fields_drop.value = value
+        self.fields_drop.layout.width = "auto"
+
+    def _validate_field(self, change: dict) -> None:
+        """The traitlet field should be a valid OPTIMADE field."""
+        field = change["new"]
+        if field is None:
+            return
+        self.field = field
+        self._toggle_sort_availability()
+
+    def _get_order_icon(self) -> str:
+        """Return button icon according to sort order."""
+        if self.order == Order.ascending:
+            return "sort-up"
+        if self.order == Order.descending:
+            return "sort-down"
+        raise traitlets.TraitError(
+            f"Out of Order! Could not determine order from self.order: {self.order!r}"
+        )
+
+    def _change_order(self, change: dict) -> None:
+        """The order button has been toggled.
+
+        When the toggle-button is "pressed down", i.e., the value is `True`,
+        the order should be `descending`.
+        """
+        descending: bool = change["new"]
+        self.order = Order.descending if descending else Order.ascending
+        self.order_select.description = (
+            self.order_select.tooltip
+        ) = self.order.name.capitalize()
+        self.order_select.icon = self._get_order_icon()
+        self._toggle_sort_availability()
+
+    def _sort_clicked(self, button: dict) -> None:
+        """The Sort button has been clicked."""


### PR DESCRIPTION
Closes #207.

With this PR an additional sorting sub-widget is added to be able to sort the results.

**Features**:
- The sorting button will only be enabled, if the chosen sorting is _different_ from the current sorting.
- The sorting button will trigger a new query that includes the chosen value for the `sort` OPTIMADE query parameter.
- Add sorting options by introspection of the `/info/structures` endpoint.

Issues to be fixed later:
- The list of sorting options are maybe not as descriptive as they could have been, since they are the field names - including the provider-specific prefix, if the implementation allows sorting on this parameter.