### PR TITLE
Fix sort order width

### DIFF
--- a/optimade_client/cli/run.py
+++ b/optimade_client/cli/run.py
@@ -44,11 +44,17 @@ def main(args: list = None):
         action="store_true",
         help="Attempt to open a browser upon starting the Voilà tornado server.",
     )
+    parser.add_argument(
+        "--template",
+        type=str,
+        help="Use another template than the default.",
+    )
 
     args = parser.parse_args(args)
     log_level = args.log_level
     debug = args.debug
     open_browser = args.open_browser
+    template = args.template
 
     # Make sure Voilà is installed
     if voila is None:
@@ -87,5 +93,8 @@ def main(args: list = None):
 
     if "--debug" not in argv:
         argv.append(f"--Voila.log_level={getattr(logging, log_level.upper())}")
+
+    if template:
+        argv.append(f"--template={template}")
 
     voila(argv)

--- a/optimade_client/subwidgets/sort_selector.py
+++ b/optimade_client/subwidgets/sort_selector.py
@@ -62,7 +62,7 @@ class SortSelector(ipw.HBox):
             button_style="",
             tooltip=self.order.name.capitalize(),
             icon=self._get_order_icon(),
-            layout={"width": "101px"},
+            layout={"width": "auto", "min_width": "105px"},
         )
         self.order_select.observe(self._change_order, names="value")
 


### PR DESCRIPTION
The sort order button is a fixed width, which will clash if the CSS is changed.
This has already been observed using the `materialscloud` template.

This PR also adds a `--template` option to the `optimade-client` CLI, where one can pass a Voilà template.