### PR TITLE
Implement "asymmetric" filtering of elements when in-/excluding

### DIFF
--- a/optimade_client/subwidgets/periodic_table.py
+++ b/optimade_client/subwidgets/periodic_table.py
@@ -25,7 +25,7 @@ class PeriodicTable(ipw.VBox):
         )
         self.select_any_all = ipw.Checkbox(
             value=False,
-            description="Structures can ex-/include any chosen elements",
+            description="Structures can include any chosen elements (instead of all)",
             indent=False,
             layout={"width": "auto"},
             disabled=self.disabled,


### PR DESCRIPTION
Closes #227.

According to the outline in #227, when excluding elements this is _always_ filtered using the `HAS ANY` operator, while when including elements, this can be toggled _via_ the checkbox, the default being the `HAS ALL` operator.