### PR TITLE
Temporarily disable OMDB and OQMD

### DIFF
--- a/optimade_client/utils.py
+++ b/optimade_client/utils.py
@@ -394,7 +394,7 @@ def get_list_of_valid_providers() -> Tuple[
         # NOTE: Temporarily disable providers NOT properly satisfying the OPTIMADE specification
         # Follow issue #206: https://github.com/CasperWA/voila-optimade-client/issues/206
         # For omdb: Follow issue #246: https://github.com/CasperWA/voila-optimade-client/issues/246
-        temp_disable_providers = ["cod", "tcod", "nmd", "omdb"]
+        temp_disable_providers = ["cod", "tcod", "nmd", "omdb", "oqmd"]
         if provider.id in temp_disable_providers:
             LOGGER.debug("Temporarily disabling provider: %s", str(provider))
             invalid_providers.append((attributes.name, attributes))

--- a/optimade_client/utils.py
+++ b/optimade_client/utils.py
@@ -392,7 +392,9 @@ def get_list_of_valid_providers() -> Tuple[
         attributes = provider.attributes
 
         # NOTE: Temporarily disable providers NOT properly satisfying the OPTIMADE specification
-        temp_disable_providers = ["cod", "tcod", "nmd"]
+        # Follow issue #206: https://github.com/CasperWA/voila-optimade-client/issues/206
+        # For omdb: Follow issue #246: https://github.com/CasperWA/voila-optimade-client/issues/246
+        temp_disable_providers = ["cod", "tcod", "nmd", "omdb"]
         if provider.id in temp_disable_providers:
             LOGGER.debug("Temporarily disabling provider: %s", str(provider))
             invalid_providers.append((attributes.name, attributes))


### PR DESCRIPTION
The main issue being the client's inability to support "amputated" entries.
See #246 for more information.

OMDB will be added #206 as a reminder that it must be re-activated when #246 has been resolved.

OQMD doesn't support filters on `structure_features`, which is mandatory.