### PR TITLE
Wrap id filter value in quotes

### DIFF
--- a/optimade_client/subwidgets/provider_database.py
+++ b/optimade_client/subwidgets/provider_database.py
@@ -444,7 +444,7 @@ class ProviderImplementationChooser(  # pylint: disable=too-many-instance-attrib
         if link is not None:
             try:
                 if exclude_ids:
-                    filter_value = " AND ".join([f"id!={id_}" for id_ in exclude_ids])
+                    filter_value = " AND ".join([f'id!="{id_}"' for id_ in exclude_ids])
 
                     parsed_url = urllib.parse.urlparse(link)
                     queries = urllib.parse.parse_qs(parsed_url.query)
@@ -496,7 +496,7 @@ class ProviderImplementationChooser(  # pylint: disable=too-many-instance-attrib
             if exclude_ids:
                 filter_ += (
                     " AND ( "
-                    + " AND ".join([f"id!={id_}" for id_ in exclude_ids])
+                    + " AND ".join([f'id!="{id_}"' for id_ in exclude_ids])
                     + " )"
                 )
 


### PR DESCRIPTION
`id` filter values should be wrapped in quotation marks (`"`).

This is not the case when excluding specific database `id`s from the provider-database widget.