### PR TITLE
Properly avoid pagination for child databases

### DIFF
--- a/optimade_client/query_provider.py
+++ b/optimade_client/query_provider.py
@@ -39,7 +39,12 @@ class OptimadeQueryProviderWidget(ipw.GridspecLayout):
         width_space: int = None,
         **kwargs,
     ):
-        database_limit = database_limit if database_limit and database_limit > 0 else 10
+        # At the moment, the pagination does not work properly as each database is not tested for
+        # validity immediately, only when each "page" is loaded. This can result in the pagination
+        # failing. Instead the default is set to 100 in an attempt to never actually do paging.
+        database_limit = (
+            database_limit if database_limit and database_limit > 0 else 100
+        )
 
         layout = ipw.Layout(width="100%", height="auto")
 

--- a/optimade_client/subwidgets/provider_database.py
+++ b/optimade_client/subwidgets/provider_database.py
@@ -445,7 +445,9 @@ class ProviderImplementationChooser(  # pylint: disable=too-many-instance-attrib
         if link is not None:
             try:
                 if exclude_ids:
-                    filter_value = " AND ".join([f'id!="{id_}"' for id_ in exclude_ids])
+                    filter_value = " AND ".join(
+                        [f'NOT id="{id_}"' for id_ in exclude_ids]
+                    )
 
                     parsed_url = urllib.parse.urlparse(link)
                     queries = urllib.parse.parse_qs(parsed_url.query)
@@ -493,11 +495,11 @@ class ProviderImplementationChooser(  # pylint: disable=too-many-instance-attrib
                     }
                 }
         else:
-            filter_ = "link_type=child OR type=child"
+            filter_ = "( link_type=child OR type=child )"
             if exclude_ids:
                 filter_ += (
                     " AND ( "
-                    + " AND ".join([f'id!="{id_}"' for id_ in exclude_ids])
+                    + " AND ".join([f'NOT id="{id_}"' for id_ in exclude_ids])
                     + " )"
                 )
 


### PR DESCRIPTION
This fixes the filter query to exclude certain databases based on their IDs if needed.

It was found that, since the exclusion checks are done a page-basis (not for all immediately), issues with the pagination can occur, which is temporarily fixed by setting the default pagination number to `100`.