### PR TITLE
Use less clicks - out of sight; out of mind

### DIFF
--- a/OPTIMADE-Client.ipynb
+++ b/OPTIMADE-Client.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -16,38 +16,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "eb6ce49431104ed787478a75c603232c",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "_ColormakerRegistry()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "eff01e6ce24e44c18dda08bf792aaef2",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HeaderDescription(children=(ReportLogger(value=\"<input type='hidden' id='report_log' value='%3Cdetails%3E%0A++…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from optimade_client import (\n",
     "    HeaderDescription,\n",
@@ -60,7 +31,15 @@
     "from ipywidgets import dlink, GridspecLayout, HTML\n",
     "from IPython.display import display\n",
     "\n",
-    "selector = OptimadeQueryProviderWidget()\n",
+    "# NOTE: Temporarily disable providers NOT properly satisfying the OPTIMADE specification\n",
+    "# Follow issue #206: https://github.com/CasperWA/voila-optimade-client/issues/206\n",
+    "# For omdb: Follow issue #246: https://github.com/CasperWA/voila-optimade-client/issues/246\n",
+    "disable_providers = [\"cod\", \"tcod\", \"nmd\", \"omdb\", \"oqmd\", \"aflow\", \"matcloud\"]\n",
+    "\n",
+    "selector = OptimadeQueryProviderWidget(\n",
+    "    disable_providers=disable_providers,\n",
+    "    skip_providers=[\"exmpl\", \"optimade\", \"aiida\"],\n",
+    ")\n",
     "filters = OptimadeQueryFilterWidget()\n",
     "summary = OptimadeSummaryWidget()\n",
     "\n",
@@ -72,100 +51,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2d3ac030cdf6485683d5b2b6d41a9a45",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "OptimadeClientFAQ(children=(HTML(value='<h4 style=\"font-weight:bold;\">Why is a provider from Materials-Consort…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "OptimadeClientFAQ()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f487029ac38b404aa17481f8c881b3f3",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "OptimadeLog(children=(VBox(children=(Checkbox(value=False, description='Show DEBUG messages', indent=False), O…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "OptimadeLog()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "570112f2c3e248de887cdccaf8c39091",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HTML(value='<h2 style=\"margin-below:0px;padding-below:0px;\">Query</h2>')"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "361a51d138bb4c4887da62a0cdf76f8a",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "OptimadeQueryProviderWidget(children=(ProviderImplementationChooser(children=(Dropdown(layout=Layout(width='au…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "854f77f2025141559df74ee6803a7411",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "GridspecLayout(children=(OptimadeQueryFilterWidget(children=(HTML(value='<h4 style=\"margin:0px;padding:0px;\">A…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "display(HTML('<h2 style=\"margin-below:0px;padding-below:0px;\">Query a provider\\'s database</h2>'))\n",
     "\n",

--- a/README.md
+++ b/README.md
@@ -155,6 +155,10 @@ http://localhost:8866/
 
 To see the full list of configurations you can call `voila` and pass `--help-all`.
 
+### Running with "development" providers (Materials Cloud-specific)
+
+Set the environment variable `OPTIMADE_CLIENT_DEVELOPMENT_MODE` to `1` (the integer version for `True` (`1`) or `False` (`0`)) in order to force the use of development servers for providers (currently only relevant for Materials Cloud).
+
 ## License
 
 MIT. The terms of the license can be found in the [LICENSE](LICENSE) file.

--- a/optimade_client/cli/run.py
+++ b/optimade_client/cli/run.py
@@ -49,12 +49,18 @@ def main(args: list = None):
         type=str,
         help="Use another template than the default.",
     )
+    parser.add_argument(
+        "--dev",
+        action="store_true",
+        help="Use development servers where applicable.",
+    )
 
     args = parser.parse_args(args)
     log_level = args.log_level
     debug = args.debug
     open_browser = args.open_browser
     template = args.template
+    dev = args.dev
 
     # Make sure Voilà is installed
     if voila is None:
@@ -87,6 +93,8 @@ def main(args: list = None):
         argv.append("--debug")
     else:
         os.environ.pop("OPTIMADE_CLIENT_DEBUG", None)
+
+    os.environ["OPTIMADE_CLIENT_DEVELOPMENT_MODE"] = "1" if dev else "0"
 
     if not open_browser:
         argv.append("--no-browser")

--- a/optimade_client/query_filter.py
+++ b/optimade_client/query_filter.py
@@ -546,6 +546,9 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
         # Update list of structures in dropdown widget
         self.structure_drop.set_options(structures)
 
+        # Auto set to the first found entry
+        self.structure_drop.index = 1
+
     def retrieve_data(self, _):
         """Perform query and retrieve data"""
         self.offset = 0

--- a/optimade_client/query_filter.py
+++ b/optimade_client/query_filter.py
@@ -546,9 +546,6 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
         # Update list of structures in dropdown widget
         self.structure_drop.set_options(structures)
 
-        # Auto set to the first found entry
-        self.structure_drop.index = 1
-
     def retrieve_data(self, _):
         """Perform query and retrieve data"""
         self.offset = 0
@@ -591,10 +588,6 @@ class OptimadeQueryFilterWidget(  # pylint: disable=too-many-instance-attributes
                 links_to_page=response.get("links", {}),
                 reset_cache=True,
             )
-
-            # Note if no data has been found
-            if not data_returned:
-                self.error_or_status_messages.value = "No structures found!"
 
         except QueryError:
             self.structure_drop.reset()

--- a/optimade_client/subwidgets/results.py
+++ b/optimade_client/subwidgets/results.py
@@ -16,6 +16,7 @@ class StructureDropdown(ipw.Dropdown):
 
     NO_OPTIONS = "Search for structures ..."
     HINT = "Select a structure"
+    NO_RESULTS = "No structures found!"
 
     def __init__(self, options=None, **kwargs):
         if options is None:
@@ -27,10 +28,16 @@ class StructureDropdown(ipw.Dropdown):
 
     def set_options(self, options: list):
         """Set options with hint at top/as first entry"""
-        options.insert(0, (self.HINT, None))
+        if options:
+            first_option = (self.HINT, None)
+            index = 1
+        else:
+            first_option = (self.NO_RESULTS, None)
+            index = 0
+        options.insert(0, first_option)
         self.options = options
         with self.hold_trait_notifications():
-            self.index = 0
+            self.index = index
 
     def reset(self):
         """Reset widget"""

--- a/optimade_client/subwidgets/results.py
+++ b/optimade_client/subwidgets/results.py
@@ -65,7 +65,7 @@ class ResultsPageChooser(ipw.HBox):  # pylint: disable=too-many-instance-attribu
         self._cache = {}
         self.__last_page_offset: typing.Union[None, int] = None
         self.__last_page_number: typing.Union[None, int] = None
-        self._layout = ipw.Layout(width="auto")
+        self._layout = kwargs.pop("layout", ipw.Layout(width="auto"))
 
         self._page_limit = page_limit
         self._data_returned = 0

--- a/optimade_client/summary.py
+++ b/optimade_client/summary.py
@@ -238,6 +238,9 @@ document.body.removeChild(link);" />
             self._update_options()
             self.unfreeze()
 
+            # Auto-choose the first option in the dropdown (CIF)
+            self.dropdown.index = 1
+
     def _initialize_options(self) -> None:
         """Initialize options according to installed packages"""
         for imported_object, adapter_format in [

--- a/optimade_client/utils.py
+++ b/optimade_client/utils.py
@@ -387,9 +387,9 @@ def get_versioned_base_url(  # pylint: disable=too-many-branches
     return ""
 
 
-def get_list_of_valid_providers() -> Tuple[
-    List[Tuple[str, LinksResourceAttributes]], List[str]
-]:
+def get_list_of_valid_providers(  # pylint: disable=too-many-branches
+    disable_providers: List[str] = None, skip_providers: List[str] = None
+) -> Tuple[List[Tuple[str, LinksResourceAttributes]], List[str]]:
     """Get curated list of database providers
 
     Return formatted list of tuples to use with a dropdown-widget.
@@ -397,22 +397,19 @@ def get_list_of_valid_providers() -> Tuple[
     providers = fetch_providers()
     res = []
     invalid_providers = []
+    disable_providers = disable_providers or []
+    skip_providers = skip_providers or ["exmpl", "optimade", "aiida"]
 
     for entry in providers:
         provider = LinksResource(**entry)
 
-        # Skip if "exmpl", "optimade" or "aiida"
-        if provider.id in ["exmpl", "optimade", "aiida"]:
+        if provider.id in skip_providers:
             LOGGER.debug("Skipping provider: %s", provider)
             continue
 
         attributes = provider.attributes
 
-        # NOTE: Temporarily disable providers NOT properly satisfying the OPTIMADE specification
-        # Follow issue #206: https://github.com/CasperWA/voila-optimade-client/issues/206
-        # For omdb: Follow issue #246: https://github.com/CasperWA/voila-optimade-client/issues/246
-        temp_disable_providers = ["cod", "tcod", "nmd", "omdb", "oqmd"]
-        if provider.id in temp_disable_providers:
+        if provider.id in disable_providers:
             LOGGER.debug("Temporarily disabling provider: %s", str(provider))
             invalid_providers.append((attributes.name, attributes))
             continue


### PR DESCRIPTION
Implement suggestions as per #276.
Closes #276.

There is still one issue that will be kept open (the second point in #276), see #278.

In this PR:
- [X] The dropdown of databases (not providers) is hidden, along with the page chooser, when the number of databases is <=1.
- [X] The first choice from the results dropdown and format dropdown are chosen automatically, when available.
  This means the CIF format is the chosen default download format.
- [X] Move "No structures found!" message into the results dropdown, instead of writing it as a special message below.
- [x] Add variable to dynamically disallow certain providers (and their databases) according to their `"id"`.
- [x] Add possibility to use development servers of providers (if available, currently only relevant for Materials Cloud).