### PR TITLE
Disable MPDS provider

### DIFF
--- a/OPTIMADE-Client.ipynb
+++ b/OPTIMADE-Client.ipynb
@@ -34,7 +34,7 @@
     "# NOTE: Temporarily disable providers NOT properly satisfying the OPTIMADE specification\n",
     "# Follow issue #206: https://github.com/CasperWA/voila-optimade-client/issues/206\n",
     "# For omdb: Follow issue #246: https://github.com/CasperWA/voila-optimade-client/issues/246\n",
-    "disable_providers = [\"cod\", \"tcod\", \"nmd\", \"omdb\", \"oqmd\", \"aflow\", \"matcloud\"]\n",
+    "disable_providers = [\"cod\", \"tcod\", \"nmd\", \"omdb\", \"oqmd\", \"aflow\", \"matcloud\", \"mpds\"]\n",
     "\n",
     "selector = OptimadeQueryProviderWidget(\n",
     "    disable_providers=disable_providers,\n",

--- a/optimade_client/subwidgets/filter_inputs.py
+++ b/optimade_client/subwidgets/filter_inputs.py
@@ -462,7 +462,7 @@ class FilterInputs(FilterTabSection):
             widget = self.query_fields[field].input_widget
             cached_value: Tuple[int, int] = widget.value
             for attr in ("min", "max"):
-                if attr in config:
+                if attr in config and config[attr] is not None:
                     try:
                         new_value = int(config[attr])
                     except (TypeError, ValueError) as exc:

--- a/optimade_client/utils.py
+++ b/optimade_client/utils.py
@@ -34,10 +34,6 @@ from optimade_client.logger import LOGGER
 __optimade_version__ = [
     "1.0.1",
     "1.0.0",
-    "1.0.0-rc.2",
-    "1.0.0-rc.1",
-    "0.10.1",
-    "0.10.0",
 ]
 
 TIMEOUT_SECONDS = 10  # Seconds before URL query timeout is raised
@@ -286,7 +282,7 @@ for ver in __optimade_version__:
             f"/v{'.'.join(ver.split('-')[0].split('+')[0].split('.')[:3])}",  # major.minor.patch
         ]
     )
-VERSION_PARTS = sorted(set(VERSION_PARTS), reverse=True)
+VERSION_PARTS = sorted(sorted(set(VERSION_PARTS), reverse=True), key=len)
 LOGGER.debug("All known version editions: %s", VERSION_PARTS)
 
 
@@ -583,7 +579,7 @@ def check_entry_properties(
     :param checks: An iterable, which only recognizes the following str entries:
     "sort", "sortable", "present", "queryable"
     The first two and latter two represent the same thing, i.e., whether a property is sortable
-    and whether a property is present in the entry-endpoint's resource's attributes, respsectively.
+    and whether a property is present in the entry-endpoint's resource's attributes, respectively.
     :param properties: Can be either a list or not of properties to check.
     :param entry_endpoint: A valid entry-endpoint for the OPTIMADE implementation,
     e.g., "structures", "_exmpl_calculations", or "/extensions/structures".


### PR DESCRIPTION
They are very specific concerning page_limit - this is fine, but the
implementation also doesn't support the ANY filter operator used to
filter out `"assemblies"` structures.

In attempting to align with MPDS some minor corrections were made.