### PR TITLE
Fix filtering `/links` & update to OPTIMADE v1.1.0

### DIFF
--- a/optimade_client/subwidgets/provider_database.py
+++ b/optimade_client/subwidgets/provider_database.py
@@ -569,7 +569,7 @@ class ProviderImplementationChooser(  # pylint: disable=too-many-instance-attrib
                     }
                 }
         else:
-            filter_ = "( link_type=child OR type=child )"
+            filter_ = '( link_type="child" OR type="child" )'
             if exclude_ids:
                 filter_ += (
                     " AND ( "

--- a/optimade_client/utils.py
+++ b/optimade_client/utils.py
@@ -32,6 +32,7 @@ from optimade_client.logger import LOGGER
 
 # Supported OPTIMADE spec versions
 __optimade_version__ = [
+    "1.1.0",
     "1.0.1",
     "1.0.0",
 ]


### PR DESCRIPTION
Fixes #334.

Update to support v1.1.0.
The main difference for the client is the `species.mass` value type.