### PR TITLE
Use a more vertical layout by default

### DIFF
--- a/OPTIMADE-Client.ipynb
+++ b/OPTIMADE-Client.ipynb
@@ -26,7 +26,7 @@
     "    OptimadeQueryFilterWidget,\n",
     "    OptimadeSummaryWidget,\n",
     ")\n",
-    "from ipywidgets import dlink, GridspecLayout, HTML\n",
+    "from ipywidgets import dlink, HTML\n",
     "from IPython.display import display\n",
     "\n",
     "# NOTE: Temporarily disable providers NOT properly satisfying the OPTIMADE specification\n",
@@ -57,7 +57,7 @@
     "    provider_database_groupings=database_grouping,\n",
     ")\n",
     "filters = OptimadeQueryFilterWidget()\n",
-    "summary = OptimadeSummaryWidget()\n",
+    "summary = OptimadeSummaryWidget(direction=\"horizontal\")\n",
     "\n",
     "_ = dlink((selector, 'database'), (filters, 'database'))\n",
     "_ = dlink((filters, 'structure'), (summary, 'entity'))\n",
@@ -91,13 +91,7 @@
    "source": [
     "display(HTML('<h2 style=\"margin-below:0px;padding-below:0px;\">Query a provider\\'s database</h2>'))\n",
     "\n",
-    "display(selector)\n",
-    "\n",
-    "filters_summary = GridspecLayout(1, 31)\n",
-    "filters_summary[:, :16] = filters\n",
-    "filters_summary[:, 17:] = summary\n",
-    "\n",
-    "display(filters_summary)"
+    "display(selector, filters, summary)"
    ],
    "outputs": [],
    "metadata": {}


### PR DESCRIPTION
This is done to accommodate especially the use of the application in
AiiDAlab, where the applications have a limited width to expand into and
some widgets (especially the periodic table) will become truncated.

Closes #336.

I'll grant that this doesn't fix the *actual* issue that's being highlighted in #336, however it does mitigate it to the extend that is possible here. To properly fix this issue, the periodic table widget needs support for scrolling. However, this repository does not develop that particular widget, instead, please seek out [osscar-org/widget-periodictable](https://github.com/osscar-org/widget-periodictable).