### PR TITLE
pinning ipywidget-extended version to 1.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ appdirs~=1.4.4
 ase~=3.22
 cachecontrol[filecache]~=0.12.11
 ipywidgets~=7.7
-ipywidgets-extended>=1.1.1,<2
+ipywidgets-extended==1.1.1
 nglview~=3.0
 optimade~=0.18.0
 pandas~=1.3


### PR DESCRIPTION
Work-around for #437 