### PR TITLE
Avoid using v1.2.0 for ipywidgets-extended

### DIFF
--- a/.aiidalab/requirements.txt
+++ b/.aiidalab/requirements.txt
@@ -1,7 +1,7 @@
 appdirs~=1.4.4
 cachecontrol[filecache]~=0.12.6
 ipywidgets~=7.6
-ipywidgets-extended>=1.1.1,<2
+ipywidgets-extended>=1.1.1,<2,!=1.2.0
 nglview>=2.7
 optimade~=0.16.1
 pandas~=1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ appdirs~=1.4.4
 ase~=3.22
 cachecontrol[filecache]~=0.12.11
 ipywidgets~=7.7
-ipywidgets-extended==1.1.1
+ipywidgets-extended>=1.1.1,<2,!=1.2.0
 nglview~=3.0
 optimade~=0.18.0
 pandas~=1.3

--- a/requirements/requirements_base.txt
+++ b/requirements/requirements_base.txt
@@ -1,7 +1,7 @@
 appdirs~=1.4.4
 cachecontrol[filecache]~=0.12.11
 ipywidgets~=7.7
-ipywidgets-extended>=1.1.1,<2
+ipywidgets-extended>=1.1.1,<2,!=1.2.0
 nglview~=3.0
 optimade~=0.18.0
 pandas~=1.3


### PR DESCRIPTION
This is to avoid using v1.2.0 as well as have dependabot avoid updating to it.