### PR TITLE
SortSelector widget use nsites as default field to sort

### DIFF
--- a/optimade_client/subwidgets/sort_selector.py
+++ b/optimade_client/subwidgets/sort_selector.py
@@ -23,7 +23,7 @@ class SortSelector(ipw.HBox):
     """
 
     NO_AVAILABLE_FIELDS = "Not available"
-    DEFAULT_FIELD = "id"
+    DEFAULT_FIELD = "nsites"
 
     field = traitlets.Unicode("", allow_none=False)
     order = traitlets.UseEnum(Order, default_value=Order.ASCENDING)


### PR DESCRIPTION
This is also one thing mentioned by Nicola, it makes more sense that the queried structures are sorted by `nsites` and show the smallest structure first.