### PR TITLE
Test with Python 3.10

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - name: Checkout repository

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Database :: Front-Ends",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Chemistry",


### PR DESCRIPTION
We're trying to use Python 3.10 in AiiDAlab and need to test if all dependencies support it.

`optimade-client` currently declares support only up to Python 3.9 . Is there any known reason that it doesn't support higher versions?

cc @unkcpz 